### PR TITLE
Fix message type name calculation for nested messages and gogo-proto.

### DIFF
--- a/internal/go/skycfg/proto_enum.go
+++ b/internal/go/skycfg/proto_enum.go
@@ -1,14 +1,10 @@
 package skycfg
 
 import (
-	"bytes"
-	"compress/gzip"
 	"fmt"
-	"io/ioutil"
 	"sort"
 	"strings"
 
-	"github.com/golang/protobuf/proto"
 	descriptor_pb "github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"github.com/google/skylark"
 )
@@ -70,22 +66,7 @@ type protoEnum interface {
 
 func enumDescriptor(enum protoEnum) (*descriptor_pb.FileDescriptorProto, []int) {
 	gzBytes, path := enum.EnumDescriptor()
-	gz, err := gzip.NewReader(bytes.NewReader(gzBytes))
-	if err != nil {
-		panic(fmt.Sprintf("EnumDescriptor: %v", err))
-	}
-	defer gz.Close()
-
-	fileDescBytes, err := ioutil.ReadAll(gz)
-	if err != nil {
-		panic(fmt.Sprintf("EnumDescriptor: %v", err))
-	}
-
-	fileDesc := &descriptor_pb.FileDescriptorProto{}
-	if err := proto.Unmarshal(fileDescBytes, fileDesc); err != nil {
-		panic(fmt.Sprintf("EnumDescriptor: %v", err))
-	}
-	return fileDesc, path
+	return mustParseFileDescriptor(gzBytes), path
 }
 
 func enumTypeName(enum protoEnum) string {

--- a/internal/go/skycfg/proto_message.go
+++ b/internal/go/skycfg/proto_message.go
@@ -29,7 +29,7 @@ var _ skylark.HasSetField = (*skyProtoMessage)(nil)
 func (msg *skyProtoMessage) String() string {
 	return fmt.Sprintf("<%s %s>", msg.Type(), proto.CompactTextString(msg.msg))
 }
-func (msg *skyProtoMessage) Type() string        { return proto.MessageName(msg.msg) }
+func (msg *skyProtoMessage) Type() string        { return messageTypeName(msg.msg) }
 func (msg *skyProtoMessage) Truth() skylark.Bool { return skylark.True }
 
 func (msg *skyProtoMessage) Freeze() {
@@ -376,7 +376,7 @@ func typeName(t reflect.Type) string {
 	messageType := reflect.TypeOf((*proto.Message)(nil)).Elem()
 	enumType := reflect.TypeOf((*protoEnum)(nil)).Elem()
 	if t.Implements(messageType) {
-		typeName = proto.MessageName(reflect.Zero(t).Interface().(proto.Message))
+		typeName = messageTypeName(reflect.Zero(t).Interface().(proto.Message))
 	} else if t.Implements(enumType) {
 		typeName = enumTypeName(reflect.Zero(t).Interface().(protoEnum))
 	}

--- a/internal/go/skycfg/proto_message_type.go
+++ b/internal/go/skycfg/proto_message_type.go
@@ -91,10 +91,7 @@ func (mt *skyProtoMessageType) Hash() (uint32, error) {
 }
 
 func (mt *skyProtoMessageType) Name() string {
-	if mt.fileDesc.GetPackage() == "" {
-		return mt.msgDesc.GetName()
-	}
-	return fmt.Sprintf("%s.%s", mt.fileDesc.GetPackage(), mt.msgDesc.GetName())
+	return messageTypeName(mt.emptyMsg)
 }
 
 func (mt *skyProtoMessageType) Attr(attrName string) (skylark.Value, error) {

--- a/internal/go/skycfg/proto_test.go
+++ b/internal/go/skycfg/proto_test.go
@@ -35,6 +35,7 @@ func (*gogoRegistry) UnstableEnumValueMap(name string) map[string]int32 {
 }
 
 func skyEval(t *testing.T, src string) skylark.Value {
+	t.Helper()
 	globals := skylark.StringDict{
 		"proto":      NewProtoModule(nil),
 		"gogo_proto": NewProtoModule(&gogoRegistry{}),
@@ -295,6 +296,7 @@ func TestMessageAttrNames(t *testing.T) {
 		"r_submsg",
 		"map_string",
 		"map_submsg",
+		"f_nested_submsg",
 		"f_toplevel_enum",
 		"f_nested_enum",
 	}
@@ -331,6 +333,9 @@ func TestMessageV2(t *testing.T) {
 				f_string = "map_submsg val",
 			),
 		},
+		f_nested_submsg = proto.package("skycfg.test_proto").MessageV2.NestedMessage(
+			f_string = "nested_submsg val",
+		),
 		f_toplevel_enum = proto.package("skycfg.test_proto").ToplevelEnumV2.TOPLEVEL_ENUM_V2_B,
 		f_nested_enum = proto.package("skycfg.test_proto").MessageV2.NestedEnum.NESTED_ENUM_B,
 	)`)
@@ -359,6 +364,9 @@ func TestMessageV2(t *testing.T) {
 				FString: proto.String("map_submsg val"),
 			},
 		},
+		FNestedSubmsg: &pb.MessageV2_NestedMessage{
+			FString: proto.String("nested_submsg val"),
+		},
 		FToplevelEnum: pb.ToplevelEnumV2_TOPLEVEL_ENUM_V2_B.Enum(),
 		FNestedEnum:   pb.MessageV2_NESTED_ENUM_B.Enum(),
 	}
@@ -380,6 +388,7 @@ func TestMessageV2(t *testing.T) {
 		"r_submsg":        `[<skycfg.test_proto.MessageV2 f_string:"string in r_submsg" >]`,
 		"map_string":      `{"map_string key": "map_string val"}`,
 		"map_submsg":      `{"map_submsg key": <skycfg.test_proto.MessageV2 f_string:"map_submsg val" >}`,
+		"f_nested_submsg": `<skycfg.test_proto.MessageV2.NestedMessage f_string:"nested_submsg val" >`,
 		"f_toplevel_enum": `<skycfg.test_proto.ToplevelEnumV2 TOPLEVEL_ENUM_V2_B=1>`,
 		"f_nested_enum":   `<skycfg.test_proto.MessageV2.NestedEnum NESTED_ENUM_B=1>`,
 	}
@@ -423,6 +432,9 @@ func TestMessageV3(t *testing.T) {
 				f_string = "map_submsg val",
 			),
 		},
+		f_nested_submsg = proto.package("skycfg.test_proto").MessageV3.NestedMessage(
+			f_string = "nested_submsg val",
+		),
 		f_toplevel_enum = proto.package("skycfg.test_proto").ToplevelEnumV3.TOPLEVEL_ENUM_V3_B,
 		f_nested_enum = proto.package("skycfg.test_proto").MessageV3.NestedEnum.NESTED_ENUM_B,
 	)`)
@@ -451,6 +463,9 @@ func TestMessageV3(t *testing.T) {
 				FString: "map_submsg val",
 			},
 		},
+		FNestedSubmsg: &pb.MessageV3_NestedMessage{
+			FString: "nested_submsg val",
+		},
 		FToplevelEnum: pb.ToplevelEnumV3_TOPLEVEL_ENUM_V3_B,
 		FNestedEnum:   pb.MessageV3_NESTED_ENUM_B,
 	}
@@ -472,6 +487,7 @@ func TestMessageV3(t *testing.T) {
 		"r_submsg":        `[<skycfg.test_proto.MessageV3 f_string:"string in r_submsg" >]`,
 		"map_string":      `{"map_string key": "map_string val"}`,
 		"map_submsg":      `{"map_submsg key": <skycfg.test_proto.MessageV3 f_string:"map_submsg val" >}`,
+		"f_nested_submsg": `<skycfg.test_proto.MessageV3.NestedMessage f_string:"nested_submsg val" >`,
 		"f_toplevel_enum": `<skycfg.test_proto.ToplevelEnumV3 TOPLEVEL_ENUM_V3_B=1>`,
 		"f_nested_enum":   `<skycfg.test_proto.MessageV3.NestedEnum NESTED_ENUM_B=1>`,
 	}
@@ -515,6 +531,9 @@ func TestMessageGogo(t *testing.T) {
 				f_string = "map_submsg val",
 			),
 		},
+		f_nested_submsg = gogo_proto.package("skycfg.test_proto").MessageGogo.NestedMessage(
+			f_string = "nested_submsg val",
+		),
 		f_toplevel_enum = proto.package("skycfg.test_proto").ToplevelEnumV2.TOPLEVEL_ENUM_V2_B,
 		f_nested_enum = gogo_proto.package("skycfg.test_proto").MessageGogo.NestedEnum.NESTED_ENUM_B,
 	)`)
@@ -543,6 +562,9 @@ func TestMessageGogo(t *testing.T) {
 				FString: proto.String("map_submsg val"),
 			},
 		},
+		FNestedSubmsg: &pb.MessageGogo_NestedMessage{
+			FString: proto.String("nested_submsg val"),
+		},
 		FToplevelEnum: pb.ToplevelEnumV2_TOPLEVEL_ENUM_V2_B.Enum(),
 		FNestedEnum:   pb.MessageGogo_NESTED_ENUM_B.Enum(),
 	}
@@ -564,6 +586,7 @@ func TestMessageGogo(t *testing.T) {
 		"r_submsg":        `[<skycfg.test_proto.MessageV2 f_string:"string in r_submsg" >]`,
 		"map_string":      `{"map_string key": "map_string val"}`,
 		"map_submsg":      `{"map_submsg key": <skycfg.test_proto.MessageV2 f_string:"map_submsg val" >}`,
+		"f_nested_submsg": `<skycfg.test_proto.MessageGogo.NestedMessage f_string:"nested_submsg val" >`,
 		"f_toplevel_enum": `<skycfg.test_proto.ToplevelEnumV2 TOPLEVEL_ENUM_V2_B=1>`,
 		"f_nested_enum":   `<skycfg.test_proto.MessageGogo.NestedEnum NESTED_ENUM_B=1>`,
 	}

--- a/internal/go/skycfg/proto_util.go
+++ b/internal/go/skycfg/proto_util.go
@@ -1,0 +1,60 @@
+package skycfg
+
+import (
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"io/ioutil"
+	"strings"
+
+	"github.com/golang/protobuf/descriptor"
+	"github.com/golang/protobuf/proto"
+	descriptor_pb "github.com/golang/protobuf/protoc-gen-go/descriptor"
+)
+
+func mustParseFileDescriptor(gzBytes []byte) *descriptor_pb.FileDescriptorProto {
+	gz, err := gzip.NewReader(bytes.NewReader(gzBytes))
+	if err != nil {
+		panic(fmt.Sprintf("EnumDescriptor: %v", err))
+	}
+	defer gz.Close()
+
+	fileDescBytes, err := ioutil.ReadAll(gz)
+	if err != nil {
+		panic(fmt.Sprintf("EnumDescriptor: %v", err))
+	}
+
+	fileDesc := &descriptor_pb.FileDescriptorProto{}
+	if err := proto.Unmarshal(fileDescBytes, fileDesc); err != nil {
+		panic(fmt.Sprintf("EnumDescriptor: %v", err))
+	}
+	return fileDesc
+}
+
+func messageTypeName(msg proto.Message) string {
+	if hasName, ok := msg.(interface {
+		XXX_MessageName() string
+	}); ok {
+		return hasName.XXX_MessageName()
+	}
+
+	hasDesc, ok := msg.(descriptor.Message)
+	if !ok {
+		return proto.MessageName(msg)
+	}
+
+	gzBytes, path := hasDesc.Descriptor()
+	fileDesc := mustParseFileDescriptor(gzBytes)
+	var chunks []string
+	if pkg := fileDesc.GetPackage(); pkg != "" {
+		chunks = append(chunks, pkg)
+	}
+
+	msgDesc := fileDesc.MessageType[path[0]]
+	for ii := 1; ii < len(path); ii++ {
+		chunks = append(chunks, msgDesc.GetName())
+		msgDesc = msgDesc.NestedType[path[ii]]
+	}
+	chunks = append(chunks, msgDesc.GetName())
+	return strings.Join(chunks, ".")
+}

--- a/testdata/test_proto_gogo.proto
+++ b/testdata/test_proto_gogo.proto
@@ -33,6 +33,11 @@ message MessageGogo {
   map<string, string>    map_string = 12;
   map<string, MessageV2> map_submsg = 13;
 
+  message NestedMessage {
+    optional string f_string = 1;
+  }
+  optional NestedMessage f_nested_submsg = 16;
+
   enum NestedEnum {
     NESTED_ENUM_A = 0;
     NESTED_ENUM_B = 1;
@@ -40,5 +45,5 @@ message MessageGogo {
   optional ToplevelEnumV2 f_toplevel_enum = 14;
   optional NestedEnum f_nested_enum = 15;
 
-  // NEXT: 16
+  // NEXT: 17
 }

--- a/testdata/test_proto_v2.proto
+++ b/testdata/test_proto_v2.proto
@@ -21,6 +21,11 @@ message MessageV2 {
   map<string, string>    map_string = 12;
   map<string, MessageV2> map_submsg = 13;
 
+  message NestedMessage {
+    optional string f_string = 1;
+  }
+  optional NestedMessage f_nested_submsg = 16;
+
   enum NestedEnum {
     NESTED_ENUM_A = 0;
     NESTED_ENUM_B = 1;
@@ -28,7 +33,7 @@ message MessageV2 {
   optional ToplevelEnumV2 f_toplevel_enum = 14;
   optional NestedEnum f_nested_enum = 15;
 
-  // NEXT: 16
+  // NEXT: 17
 }
 
 enum ToplevelEnumV2 {

--- a/testdata/test_proto_v3.proto
+++ b/testdata/test_proto_v3.proto
@@ -21,6 +21,11 @@ message MessageV3 {
   map<string, string>    map_string = 12;
   map<string, MessageV3> map_submsg = 13;
 
+  message NestedMessage {
+    string f_string = 1;
+  }
+  NestedMessage f_nested_submsg = 16;
+
   enum NestedEnum {
     NESTED_ENUM_A = 0;
     NESTED_ENUM_B = 1;
@@ -29,7 +34,7 @@ message MessageV3 {
   ToplevelEnumV3 f_toplevel_enum = 14;
   NestedEnum f_nested_enum = 15;
 
-  // NEXT: 16
+  // NEXT: 17
 }
 
 enum ToplevelEnumV3 {


### PR DESCRIPTION
The previous code was using `proto.MessageName()` in some cases and a
calculation from the descriptors in others. This caused multiple issues:

* `proto.MessageName()` doesn't work for code generated by gogo-proto,
  so type checks based on the message name would fail.

* The name calculation for descriptors worked the same between codegens,
  but returned incorrect names for nested messages.

This PR switches to using only calculation from descriptors, with a
correct implementation thereof.