### PR TITLE
Handle newtypes in the Kubernetes API (+ better type errors).

### DIFF
--- a/internal/go/skycfg/proto_message.go
+++ b/internal/go/skycfg/proto_message.go
@@ -359,7 +359,8 @@ func scalarFromSkylark(t reflect.Type, sky skylark.Value) (reflect.Value, error)
 		val := reflect.New(t.Elem())
 		elem, err := scalarFromSkylark(t.Elem(), sky)
 		if err != nil {
-			return reflect.Value{}, err
+			// Recompute the type error based on the pointer type.
+			return reflect.Value{}, typeError(t, sky)
 		}
 		val.Elem().Set(elem)
 		return val, nil
@@ -441,6 +442,9 @@ func typeName(t reflect.Type) string {
 	enumType := reflect.TypeOf((*protoEnum)(nil)).Elem()
 	if t.Implements(enumType) {
 		return enumTypeName(reflect.Zero(t).Interface().(protoEnum))
+	}
+	if t.PkgPath() == "" {
+		return t.String()
 	}
 	return fmt.Sprintf("%q.%s", t.PkgPath(), t.Name())
 }

--- a/internal/go/skycfg/proto_test.go
+++ b/internal/go/skycfg/proto_test.go
@@ -683,7 +683,7 @@ func TestAttrValidation(t *testing.T) {
 		},
 		{
 			src:     `MessageV3(map_submsg = {'': 456})`,
-			wantErr: "TypeError: value 456 (type `int') can't be assigned to type `test_proto.MessageV3'.",
+			wantErr: "TypeError: value 456 (type `int') can't be assigned to type `skycfg.test_proto.MessageV3'.",
 		},
 		{
 			src:     `MessageV3(f_submsg = proto.package("skycfg.test_proto").MessageV2())`,


### PR DESCRIPTION
The Kubernetes generated code uses newtype'd strings instead of enums, which would cause a panic when assigning:

```
>>> core_v1 = proto.package("k8s.io.api.core.v1")
>>> core_v1.Toleration(operator = "Equal")
panic: reflect.Set: value of type string is not assignable to type v1.TolerationOperator

goroutine 1 [running]:
reflect.Value.assignTo(0x1a557c0, 0xc000401690, 0x98, 0x1bbef58, 0xb, 0x1a549c0, 0x0, 0x1, 0x1, 0x0)
	/Users/jmillikin/.opt/go-1.11/src/reflect/value.go:2239 +0x44c
reflect.Value.Set(0x1a549c0, 0xc000210100, 0x198, 0x1a557c0, 0xc000401690, 0x98)
	/Users/jmillikin/.opt/go-1.11/src/reflect/value.go:1373 +0xa7
github.com/stripe/skycfg/internal/go/skycfg.(*skyProtoMessage).setSingleField(0xc000181620, 0x1aa4d40, 0x8, 0xc0001000c0, 0x1ce5de0, 0xc0001455f0, 0x0, 0x0)
	/Users/jmillikin/src/github.com/stripe/skycfg/internal/go/skycfg/proto_message.go:187 +0x2b4
```

This wasn't previously noticed because our internal tools were regenerating the .pb.go sources with plain go-protobuf, which drops the newtypes.

This PR checks for an impossible assignment and either converts to the newtype or raises a `TypeError`. Unfortunately there's no obvious way to validate that only defined values are assigned to these fields, but at least it doesn't panic on valid input.

```
>>> core_v1 = proto.package("k8s.io.api.core.v1")
>>> core_v1.Toleration(operator = "Equal")
<k8s.io.api.core.v1.Toleration operator:"Equal" >
>>>
```

