### PR TITLE
Special-case Kubernetes protos to avoid panics from jsonpb.

### DIFF
--- a/internal/go/skycfg/json.go
+++ b/internal/go/skycfg/json.go
@@ -80,6 +80,15 @@ func fnYamlMarshal(t *skylark.Thread, fn *skylark.Builtin, args skylark.Tuple, k
 // Adapted from struct-specific JSON function:
 // https://github.com/google/skylark/blob/67717b5898061eb621519a94a4b89cedede9bca0/skylarkstruct/struct.go#L321
 func writeJSON(out *bytes.Buffer, v skylark.Value) error {
+	if marshaler, ok := v.(json.Marshaler); ok {
+		jsonData, err := marshaler.MarshalJSON()
+		if err != nil {
+			return err
+		}
+		out.Write(jsonData)
+		return nil
+	}
+
 	switch v := v.(type) {
 	case skylark.NoneType:
 		out.WriteString("null")
@@ -127,7 +136,7 @@ func writeJSON(out *bytes.Buffer, v skylark.Value) error {
 		}
 		out.WriteByte('}')
 	default:
-		return fmt.Errorf("cannot convert %s to JSON", v.Type())
+		return fmt.Errorf("TypeError: value %s (type `%s') can't be converted to JSON.", v.String(), v.Type())
 	}
 	return nil
 }

--- a/internal/go/skycfg/proto_test.go
+++ b/internal/go/skycfg/proto_test.go
@@ -659,6 +659,10 @@ func TestAttrValidation(t *testing.T) {
 			src:     `MessageV3(f_bool = '')`,
 			wantErr: "TypeError: value \"\" (type `string') can't be assigned to type `bool'.",
 		},
+		{
+			src:     `MessageV3(f_toplevel_enum = 0)`,
+			wantErr: "TypeError: value 0 (type `int') can't be assigned to type `skycfg.test_proto.ToplevelEnumV3'.",
+		},
 
 		// Non-scalar type mismatch
 		{


### PR DESCRIPTION
This unifies the `json.marshal()` and `proto.to_json()` paths for protobuf messages, and adds a special case for Kubernetes protos that lets marshaling work despite the presence of non-message fields.

See https://github.com/stripe/skycfg/pull/6 for context.

```
>>> meta_v1 = proto.package("k8s.io.apimachinery.pkg.apis.meta.v1")
>>> msg = meta_v1.ObjectMeta()
>>> proto.to_json(msg)
"{\"creationTimestamp\":null}"
>>> json.marshal(msg)
"{\"creationTimestamp\":null}"
```