### PR TITLE
Disable testing WASM example on Go master.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,4 +27,4 @@ install:
 script:
   - go test -v ./...
   - ( cd _examples/repl && go build . )
-  - ( cd _examples/wasm && GOOS=js GOARCH=wasm go build -o skycfg.wasm . )
+  - if [[ "$TRAVIS_GO_VERSION" != "master" ]]; then ( cd _examples/wasm && GOOS=js GOARCH=wasm go build -o skycfg.wasm . ); fi


### PR DESCRIPTION
https://go-review.googlesource.com/c/142004 was a breaking change in the upstream `syscall/js` package, which the WASM example uses to export Go functions into the Javascript namespace. Our example uses the 1.11 type.

We'll need to update the example code later when 1.12 is released. Until then, disable building the WASM example with Go master to avoid spurious failures.