### PR TITLE
Use custom proto registry for proto.package.

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -2,7 +2,6 @@ github.com/gogo/protobuf v1.1.1 h1:72R+M5VuhED/KujmZVcIquuo8mBgX4oVda//DQb3PXo=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
-github.com/jmillikin-stripe/godebug v0.0.0-20180620173319-8279e1966bc1 h1:JgsVrDAUy59N248f3l4RGZ0hij5u1HTit8iJr1mFSBY=
 github.com/jmillikin-stripe/godebug v0.0.0-20180620173319-8279e1966bc1/go.mod h1:gFqr/IKD8P+Hluq9gThCR944BAu6jUqd5H/R3PrPfuM=
 github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348 h1:MtvEpTB6LX3vkb4ax0b5D2DHbNAUsen0Gx5wZoq3lV4=
 github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=

--- a/internal/go/skycfg/proto_message_type.go
+++ b/internal/go/skycfg/proto_message_type.go
@@ -27,24 +27,11 @@ import (
 	"go.starlark.net/starlark"
 )
 
-type defaultProtoRegistry struct{}
-
-func (*defaultProtoRegistry) UnstableProtoMessageType(name string) (reflect.Type, error) {
-	return proto.MessageType(name), nil
-}
-
-func (*defaultProtoRegistry) UnstableEnumValueMap(name string) map[string]int32 {
-	return proto.EnumValueMap(name)
-}
-
 // NewMessageType creates a Starlark value representing a named Protobuf message type.
 //
 // The message type must have been registered with the protobuf library, and implement
 // the expected interfaces for a generated .pb.go message struct.
 func newMessageType(registry ProtoRegistry, name string) (starlark.Value, error) {
-	if registry == nil {
-		registry = &defaultProtoRegistry{}
-	}
 	goType, err := registry.UnstableProtoMessageType(name)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Use custom registry to lookup enum names in proto package attribute call (instead of standard `proto.EnumValueMap`). This should fix issues with top-level enums (#30) when protobuf registry is overridden in the proto package (e.g gogo proto).