### PR TITLE
Give the caller a hint that the `gogocompat` module exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,3 +172,26 @@ We welcome contributions from the community. For small simple changes, go ahead 
 Skycfg depends on internal details of the go-protobuf generated code, and as such may need to be updated to work with future versions of go-protobuf. We will release Skycfg v1.0 after all dependencies on go-protobuf implementation details have been fixed, which will be after the "api-v2" branch lands in a stable release of go-protobuf.
 
 Our existing public APIs are expected to be stable even before the v1.0 release. Symbols that will change before v1.0 are hidden from the public docs and named `Unstable*`.
+
+## Known issues
+<a name="typerror-with-same-type-names></a>
+### TypeError with the same type names
+
+E.g.:
+```
+panic: TypeError: value <google.protobuf.UInt32Value value:20 > (type `google.protobuf.UInt32Value') can't be assigned to type `google.protobuf.UInt32Value'.
+```
+
+On the face of it this looks confusing, and it is. It's an effect of a
+project that use `gogo_protobuf`, where some fundamental types are
+wrapped in messages that shadow the same messages defined by
+`google.protobuf`. Even though the messages seem to say that they are
+of the same type, they are actually two different types with the same
+name.
+
+For projects that use `gogo_protobuf`, e.g. envoy, this can be very confusing.
+
+To resolve this, use the package `github.com/stripe/skycfg/gogocopmat`
+in your go code. This will allow skycfg code to load
+`proto.package("gogo:google.protobuf") and the internal registry it
+creates will handle the conversion of these types.

--- a/internal/go/skycfg/proto_message.go
+++ b/internal/go/skycfg/proto_message.go
@@ -538,21 +538,13 @@ func typeName(t reflect.Type) string {
 }
 
 func typeError(t reflect.Type, sky starlark.Value) error {
-	if sky.Type() == typeName(t) {
-		return fmt.Errorf(
-			"TypeError: value %s (type `%s') can't be assigned to type `%s'."+
-				"\nThe names of the types in this error are deceptively similar.\n"+
-				"this is often because of a conflict between the google protobuf\n"+
-				"implementation and messages that are shadowing the google naming,\n"+
-				"but which are actually coming from gogoproto, which adds features\n"+
-				"with the unfortunate effect of sometimes causing this confusion.\n\n"+
-				"To address this, try adding the github.com/stripe/skycfg/gogocompat\n"+
-				"module, and follow the examples of the added diffs at\n"+
-				"https://github.com/stripe/skycfg/pull/41/files\n",
+	if sky.Type() != typeName(t) {
+		return fmt.Errorf("TypeError: value %s (type `%s') can't be assigned to type `%s'.",
 			sky.String(), sky.Type(), typeName(t))
-	} else {
-		return fmt.Errorf("TypeError: value %s (type `%s') can't be assigned to type `%s'.", sky.String(), sky.Type(), typeName(t))
 	}
+	return fmt.Errorf("TypeError: value %s (type `%s') can't be assigned to type `%s'.\n"+
+		"(see https://github.com/stripe/skycfg/README.md#typerror-with-same-type-names)",
+		sky.String(), sky.Type(), typeName(t))
 }
 
 type protoRepeated struct {

--- a/internal/go/skycfg/proto_message.go
+++ b/internal/go/skycfg/proto_message.go
@@ -538,7 +538,21 @@ func typeName(t reflect.Type) string {
 }
 
 func typeError(t reflect.Type, sky starlark.Value) error {
-	return fmt.Errorf("TypeError: value %s (type `%s') can't be assigned to type `%s'.", sky.String(), sky.Type(), typeName(t))
+	if sky.Type() == typeName(t) {
+		return fmt.Errorf(
+			"TypeError: value %s (type `%s') can't be assigned to type `%s'."+
+				"\nThe names of the types in this error are deceptively similar.\n"+
+				"this is often because of a conflict between the google protobuf\n"+
+				"implementation and messages that are shadowing the google naming,\n"+
+				"but which are actually coming from gogoproto, which adds features\n"+
+				"with the unfortunate effect of sometimes causing this confusion.\n\n"+
+				"To address this, try adding the github.com/stripe/skycfg/gogocompat\n"+
+				"module, and follow the examples of the added diffs at\n"+
+				"https://github.com/stripe/skycfg/pull/41/files\n",
+			sky.String(), sky.Type(), typeName(t))
+	} else {
+		return fmt.Errorf("TypeError: value %s (type `%s') can't be assigned to type `%s'.", sky.String(), sky.Type(), typeName(t))
+	}
 }
 
 type protoRepeated struct {

--- a/internal/go/skycfg/proto_message.go
+++ b/internal/go/skycfg/proto_message.go
@@ -543,7 +543,7 @@ func typeError(t reflect.Type, sky starlark.Value) error {
 			sky.String(), sky.Type(), typeName(t))
 	}
 	return fmt.Errorf("TypeError: value %s (type `%s') can't be assigned to type `%s'.\n"+
-		"(see https://github.com/stripe/skycfg/README.md#typerror-with-same-type-names)",
+		"(see https://github.com/stripe/skycfg/#typeerror-with-the-same-type-names)",
 		sky.String(), sky.Type(), typeName(t))
 }
 


### PR DESCRIPTION
On skycfg typeErrors where the source and destination type's
stringifcation look identical, we may have an issue with shadowed
protobuf message names due to how gogo_proto works. If a project
like envoy has chosen gogo, this will happen to all fundamental
message types (time durations, int32 uint32, etc. etc. etc.).

Tell the user this problem exists so the user doesn't have to
go through the ritual cleansing of an embarrassing trial by fire,
and the maintainers don't have to answer this question.

Also, this functions as a placeholder until this stuff has
stabilized and is documented.