### PR TITLE
autoboxing scalars to their corresponding wrapper types

### DIFF
--- a/internal/go/skycfg/proto_test.go
+++ b/internal/go/skycfg/proto_test.go
@@ -326,6 +326,12 @@ func TestMessageAttrNames(t *testing.T) {
 		"f_oneof_a",
 		"f_oneof_b",
 		"f_bytes",
+		"f_BoolValue",
+		"f_StringValue",
+		"f_DoubleValue",
+		"f_Int32Value",
+		"f_Int64Value",
+		"f_BytesValue",
 	}
 	sort.Strings(want)
 	if !reflect.DeepEqual(want, got) {

--- a/internal/go/skycfg/proto_test.go
+++ b/internal/go/skycfg/proto_test.go
@@ -332,6 +332,7 @@ func TestMessageAttrNames(t *testing.T) {
 		"f_Int32Value",
 		"f_Int64Value",
 		"f_BytesValue",
+		"r_StringValue",
 	}
 	sort.Strings(want)
 	if !reflect.DeepEqual(want, got) {

--- a/internal/go/skycfg/proto_test.go
+++ b/internal/go/skycfg/proto_test.go
@@ -332,6 +332,8 @@ func TestMessageAttrNames(t *testing.T) {
 		"f_Int32Value",
 		"f_Int64Value",
 		"f_BytesValue",
+		"f_Uint32Value",
+		"f_Uint64Value",
 		"r_StringValue",
 	}
 	sort.Strings(want)

--- a/internal/go/skycfg/skycfg_test.go
+++ b/internal/go/skycfg/skycfg_test.go
@@ -121,6 +121,7 @@ def main(ctx):
 	msg.f_Int32Value = 110
 	msg.f_Int64Value = 2148483647
 	msg.f_BytesValue = "foo/bar/baz"
+	msg.r_StringValue = ["s1","s2","s3"]
 	return [msg]
 `,
 	"test8.sky": `
@@ -205,6 +206,11 @@ func TestSkycfgEndToEnd(t *testing.T) {
 					F_Int32Value: &wrappers.Int32Value{Value: 110},
 					F_Int64Value: &wrappers.Int64Value{Value: 2148483647},
 					F_BytesValue: &wrappers.BytesValue{Value: []byte("foo/bar/baz")},
+					R_StringValue: []*wrappers.StringValue{
+						&wrappers.StringValue{Value: "s1"},
+						&wrappers.StringValue{Value: "s2"},
+						&wrappers.StringValue{Value: "s3"},
+					},
 				},
 			},
 		},

--- a/scratch.go
+++ b/scratch.go
@@ -1,0 +1,1 @@
+package skycfg

--- a/testdata/test_proto_v3.proto
+++ b/testdata/test_proto_v3.proto
@@ -19,6 +19,8 @@ syntax = "proto3";
 option go_package = "github.com/stripe/skycfg/test_proto";
 package skycfg.test_proto;
 
+import "google/protobuf/wrappers.proto";
+
 message MessageV3 {
   int32  f_int32   = 1;
   int64  f_int64   = 2;
@@ -57,7 +59,14 @@ message MessageV3 {
 
   bytes f_bytes    = 19;
 
-  // NEXT: 20
+  google.protobuf.BoolValue f_BoolValue = 20;
+  google.protobuf.StringValue f_StringValue = 21;
+  google.protobuf.DoubleValue f_DoubleValue = 22;
+  google.protobuf.Int32Value f_Int32Value = 23;
+  google.protobuf.Int64Value f_Int64Value = 24;
+  google.protobuf.BytesValue f_BytesValue = 25;
+
+  // NEXT: 26
 }
 
 enum ToplevelEnumV3 {

--- a/testdata/test_proto_v3.proto
+++ b/testdata/test_proto_v3.proto
@@ -65,10 +65,12 @@ message MessageV3 {
   google.protobuf.Int32Value f_Int32Value = 23;
   google.protobuf.Int64Value f_Int64Value = 24;
   google.protobuf.BytesValue f_BytesValue = 25;
+  google.protobuf.UInt32Value f_Uint32Value = 26;
+  google.protobuf.UInt64Value f_Uint64Value = 27;
 
-  repeated google.protobuf.StringValue r_StringValue = 26;
+  repeated google.protobuf.StringValue r_StringValue = 28;
 
-  // NEXT: 27
+  // NEXT: 29
 }
 
 enum ToplevelEnumV3 {

--- a/testdata/test_proto_v3.proto
+++ b/testdata/test_proto_v3.proto
@@ -66,7 +66,9 @@ message MessageV3 {
   google.protobuf.Int64Value f_Int64Value = 24;
   google.protobuf.BytesValue f_BytesValue = 25;
 
-  // NEXT: 26
+  repeated google.protobuf.StringValue r_StringValue = 26;
+
+  // NEXT: 27
 }
 
 enum ToplevelEnumV3 {


### PR DESCRIPTION
If a message field is typed as a wrapper type (e.g. StringValue, BoolValue, IntValue) don't throw a type error, but autobox them correspondingly. See below, 

```
syntax = "proto3";
package foo;
import "google/protobuf/wrappers.proto";

message packet { google.protobuf.StringValue val = 1; }
```

```
wkt = proto.package("google.protobuf")
foo = proto.package("foo")

def main(ctx):
    return [foo.packet(val = wkt.StringValue(value = "something"))]
    // instead we can write foo.packet(val = "something")
```

Thoughts?