### PR TITLE
extend supported types for yaml

### DIFF
--- a/internal/go/skycfg/yaml.go
+++ b/internal/go/skycfg/yaml.go
@@ -86,8 +86,19 @@ func fnYamlUnmarshal(t *starlark.Thread, fn *starlark.Builtin, args starlark.Tup
 
 // toStarlarkValue is a DFS walk to translate the DAG from go to starlark
 func toStarlarkValue(obj interface{}) (starlark.Value, error) {
+	if obj == nil {
+		return starlark.None, nil
+	}
 	rt := reflect.TypeOf(obj)
 	switch rt.Kind() {
+	case reflect.Int:
+		return starlark.MakeInt(obj.(int)), nil
+	case reflect.Uint64:
+		return starlark.MakeUint64(obj.(uint64)), nil
+	case reflect.Bool:
+		return starlark.Bool(obj.(bool)), nil
+	case reflect.Float64:
+		return starlark.Float(obj.(float64)), nil
 	case reflect.String:
 		return starlark.String(obj.(string)), nil
 	case reflect.Map:
@@ -114,6 +125,6 @@ func toStarlarkValue(obj interface{}) (starlark.Value, error) {
 		}
 		return starlark.NewList(starvals), nil
 	default:
-		return nil, fmt.Errorf("%v is not a slice, map, or string", obj)
+		return nil, fmt.Errorf("%s (%v) is not a supported type", rt.Kind(), obj)
 	}
 }

--- a/internal/go/skycfg/yaml.go
+++ b/internal/go/skycfg/yaml.go
@@ -90,17 +90,18 @@ func toStarlarkValue(obj interface{}) (starlark.Value, error) {
 		return starlark.None, nil
 	}
 	rt := reflect.TypeOf(obj)
+	v := reflect.ValueOf(obj)
 	switch rt.Kind() {
-	case reflect.Int:
-		return starlark.MakeInt(obj.(int)), nil
-	case reflect.Uint64:
-		return starlark.MakeUint64(obj.(uint64)), nil
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return starlark.MakeInt64(v.Int()), nil
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return starlark.MakeUint64(v.Uint()), nil
 	case reflect.Bool:
-		return starlark.Bool(obj.(bool)), nil
-	case reflect.Float64:
-		return starlark.Float(obj.(float64)), nil
+		return starlark.Bool(v.Bool()), nil
+	case reflect.Float32, reflect.Float64:
+		return starlark.Float(v.Float()), nil
 	case reflect.String:
-		return starlark.String(obj.(string)), nil
+		return starlark.String(v.String()), nil
 	case reflect.Map:
 		ret := &starlark.Dict{}
 		for k, v := range obj.(map[interface{}]interface{}) {

--- a/internal/go/skycfg/yaml_test.go
+++ b/internal/go/skycfg/yaml_test.go
@@ -91,7 +91,22 @@ func TestYamlToSky(t *testing.T) {
 	env := starlark.StringDict{
 		"yaml": YamlModule(),
 	}
-	skyExpr := `{"strKey": "val", "arrKey": ["a", "b"], "mapKey": {"subkey": "val"}, "uintKey": 12345678901234567890, "intKey": 123, "floatKey": 1.234, "boolKey": False, "nullKey": None}`
+
+	skyExpr := `{
+        "strKey": "val",
+        "arrKey": ["a", "b"],
+        "mapKey": {"subkey": "val"},
+        "intKey": 2147483647,
+        "int64Key": 2147483648,
+        "nIntKey": -2147483648,
+        "nInt64Key": -2147483649,
+        "uintKey": 9223372036854775808,
+        "overflowUintKey": 18446744073709551616,
+        "floatKey": 1.234,
+        "boolKey": False,
+        "nullKey": None
+    }`
+
 	v, err := starlark.Eval(
 		thread,
 		"<expr>",
@@ -124,17 +139,32 @@ func TestYamlToSky(t *testing.T) {
 		{
 			name: "key mapped to Uint",
 			key:  "uintKey",
-			want: `12345678901234567890`,
+			want: `9223372036854775808`,
+		},
+		{
+			name: "key mapped to negative Int64",
+			key:  "nInt64Key",
+			want: `-2147483649`,
 		},
 		{
 			name: "key mapped to Int",
 			key:  "intKey",
-			want: `123`,
+			want: `2147483647`,
+		},
+		{
+			name: "key mapped to Int64",
+			key:  "int64Key",
+			want: `2147483648`,
 		},
 		{
 			name: "key mapped to Float",
 			key:  "floatKey",
 			want: `1.234`,
+		},
+		{
+			name: "key mapped to Overflow Uint64",
+			key:  "overflowUintKey",
+			want: `1.84467e+19`,
 		},
 		{
 			name: "key mapped to Bool",

--- a/internal/go/skycfg/yaml_test.go
+++ b/internal/go/skycfg/yaml_test.go
@@ -91,7 +91,7 @@ func TestYamlToSky(t *testing.T) {
 	env := starlark.StringDict{
 		"yaml": YamlModule(),
 	}
-	skyExpr := `{"strKey": "val", "arrKey": ["a", "b"], "mapKey": {"subkey": "val"}}`
+	skyExpr := `{"strKey": "val", "arrKey": ["a", "b"], "mapKey": {"subkey": "val"}, "uintKey": 12345678901234567890, "intKey": 123, "floatKey": 1.234, "boolKey": False, "nullKey": None}`
 	v, err := starlark.Eval(
 		thread,
 		"<expr>",
@@ -120,6 +120,31 @@ func TestYamlToSky(t *testing.T) {
 			name: "key mapped to Map",
 			key:  "mapKey",
 			want: `{"subkey": "val"}`,
+		},
+		{
+			name: "key mapped to Uint",
+			key:  "uintKey",
+			want: `12345678901234567890`,
+		},
+		{
+			name: "key mapped to Int",
+			key:  "intKey",
+			want: `123`,
+		},
+		{
+			name: "key mapped to Float",
+			key:  "floatKey",
+			want: `1.234`,
+		},
+		{
+			name: "key mapped to Bool",
+			key:  "boolKey",
+			want: `False`,
+		},
+		{
+			name: "key mapped to Null",
+			key:  "nullKey",
+			want: `None`,
 		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {


### PR DESCRIPTION
Currently, supported fields for yaml.unmarshal is limited with strings, maps and slices. This PR will extend it and will add int, uint, float, bool, null kinds to the supported fields. 

Signed-off-by: Jon Yucel <jon.yucel@getcruise.com>