### PR TITLE
add more support for yaml key types

### DIFF
--- a/internal/go/skycfg/yaml.go
+++ b/internal/go/skycfg/yaml.go
@@ -85,41 +85,41 @@ func fnYamlUnmarshal(t *starlark.Thread, fn *starlark.Builtin, args starlark.Tup
 }
 
 // toStarlarkScalarValue converts a scalar [obj] value to its starlark Value
-func toStarlarkScalarValue(obj interface{}) (starlark.Value, error){
+func toStarlarkScalarValue(obj interface{}) (starlark.Value, bool){
 	if obj == nil {
-		return starlark.None, nil
+		return starlark.None, true
 	}
 	rt := reflect.TypeOf(obj)
 	v := reflect.ValueOf(obj)
 	switch rt.Kind() {
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		return starlark.MakeInt64(v.Int()), nil
+		return starlark.MakeInt64(v.Int()), true
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		return starlark.MakeUint64(v.Uint()), nil
+		return starlark.MakeUint64(v.Uint()), true
 	case reflect.Bool:
-		return starlark.Bool(v.Bool()), nil
+		return starlark.Bool(v.Bool()), true
 	case reflect.Float32, reflect.Float64:
-		return starlark.Float(v.Float()), nil
+		return starlark.Float(v.Float()), true
 	case reflect.String:
-		return starlark.String(v.String()), nil
+		return starlark.String(v.String()), true
 	default:
-		return nil, fmt.Errorf("%s (%v) is not a supported type", rt.Kind(), obj)
+		return nil, false
 	}
 }
 
 // toStarlarkValue is a DFS walk to translate the DAG from go to starlark
 func toStarlarkValue(obj interface{}) (starlark.Value, error) {
-	if objval, err := toStarlarkScalarValue(obj); err == nil {
-		return objval, err
+	if objval, ok := toStarlarkScalarValue(obj); ok {
+		return objval, nil
 	}
 	rt := reflect.TypeOf(obj)
 	switch rt.Kind() {
 	case reflect.Map:
 		ret := &starlark.Dict{}
 		for k, v := range obj.(map[interface{}]interface{}) {
-			keyval, err := toStarlarkScalarValue(k)
-			if err != nil {
-				return nil, err
+			keyval, ok := toStarlarkScalarValue(k)
+			if !ok {
+				return nil, fmt.Errorf("%s (%v) is not a supported key type", rt.Kind(), obj)
 			}
 			starval, err := toStarlarkValue(v)
 			if err != nil {

--- a/internal/go/skycfg/yaml_test.go
+++ b/internal/go/skycfg/yaml_test.go
@@ -104,7 +104,15 @@ func TestYamlToSky(t *testing.T) {
         "overflowUintKey": 18446744073709551616,
         "floatKey": 1.234,
         "boolKey": False,
-        "nullKey": None
+        "nullKey": None,
+        2147483647: "intKey",
+        2147483648: "int64Key",
+        -2147483648: "nIntKey",
+        -2147483649: "nInt64Key",
+        9223372036854775808: "uintKey", 
+        1.234: "floatKey",
+        False: "boolKey",
+        None: "nullKey",
     }`
 
 	v, err := starlark.Eval(
@@ -118,67 +126,104 @@ func TestYamlToSky(t *testing.T) {
 	}
 	staryaml := v.(starlark.Mapping)
 	for _, testCase := range []struct {
-		name, key, want string
-		expectedErr     error
+		name        string
+		key         starlark.Value
+		want        string
+		expectedErr error
 	}{
 		{
 			name: "key mapped to String",
-			key:  "strKey",
+			key:  starlark.String("strKey"),
 			want: `"val"`,
 		},
 		{
 			name: "key mapped to Array",
-			key:  "arrKey",
+			key:  starlark.String("arrKey"),
 			want: `["a", "b"]`,
 		},
 		{
 			name: "key mapped to Map",
-			key:  "mapKey",
+			key:  starlark.String("mapKey"),
 			want: `{"subkey": "val"}`,
 		},
 		{
 			name: "key mapped to Uint",
-			key:  "uintKey",
+			key:  starlark.String("uintKey"),
 			want: `9223372036854775808`,
 		},
 		{
 			name: "key mapped to negative Int64",
-			key:  "nInt64Key",
+			key:  starlark.String("nInt64Key"),
 			want: `-2147483649`,
 		},
 		{
 			name: "key mapped to Int",
-			key:  "intKey",
+			key:  starlark.String("intKey"),
 			want: `2147483647`,
 		},
 		{
 			name: "key mapped to Int64",
-			key:  "int64Key",
+			key:  starlark.String("int64Key"),
 			want: `2147483648`,
 		},
 		{
 			name: "key mapped to Float",
-			key:  "floatKey",
+			key:  starlark.String("floatKey"),
 			want: `1.234`,
 		},
 		{
 			name: "key mapped to Overflow Uint64",
-			key:  "overflowUintKey",
+			key:  starlark.String("overflowUintKey"),
 			want: `1.84467e+19`,
 		},
 		{
 			name: "key mapped to Bool",
-			key:  "boolKey",
+			key:  starlark.String("boolKey"),
 			want: `False`,
 		},
 		{
 			name: "key mapped to Null",
-			key:  "nullKey",
+			key:  starlark.String("nullKey"),
 			want: `None`,
+		},
+		{
+			name: "int key mapped to String",
+			key:  starlark.MakeInt(2147483647),
+			want: `"intKey"`,
+		},
+		{
+			name: "Int64 key mapped to String",
+			key:  starlark.MakeInt64(2147483648),
+			want: `"int64Key"`,
+		},
+		{
+			name: "negative Int64 key mapped to String",
+			key: starlark.MakeInt64(-2147483649),
+			want:  `"nInt64Key"`,
+		},
+		{
+			name: "Uint key mapped to String",
+			key:  starlark.MakeUint(9223372036854775808),
+			want: `"uintKey"`,
+		},
+		{
+			name: "Float key mapped to String",
+			key:  starlark.Float(1.234),
+			want: `"floatKey"`,
+		},
+		{
+			name: "Bool key mapped to String",
+			key:  starlark.Bool(false),
+			want: `"boolKey"`,
+		},
+		{
+			name: "Null key mapped to String",
+			key:  starlark.None,
+			want: `"nullKey"`,
 		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
-			got, _, err := staryaml.Get(starlark.String(testCase.key))
+			got, _, err := staryaml.Get(testCase.key)
 			if err != nil {
 				t.Errorf("error accessing key [%v] in staryaml: %v", testCase.key, err)
 			}


### PR DESCRIPTION
Right now `yaml.unmarshal` only supports string key types, while `yaml.marshal` handles other key types fine. 

- created helper `toStarlarkScalarValue`
- add support for more yaml key types: ints, uints, floats, bool, null 
- corresponding tests