### PR TITLE
Clear the message wrapper's attribute cache after bulk mutations.

### DIFF
--- a/internal/go/skycfg/proto_api.go
+++ b/internal/go/skycfg/proto_api.go
@@ -103,6 +103,7 @@ func fnProtoClear(t *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple,
 		return nil, err
 	}
 	msg.msg.Reset()
+	msg.resetAttrCache()
 	return msg, nil
 }
 
@@ -138,6 +139,7 @@ func fnProtoMerge(t *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple,
 		return nil, err
 	}
 	proto.Merge(dst.msg, src.msg)
+	dst.resetAttrCache()
 	return dst, nil
 }
 

--- a/internal/go/skycfg/proto_message.go
+++ b/internal/go/skycfg/proto_message.go
@@ -143,6 +143,10 @@ func (msg *skyProtoMessage) checkMutable(verb string) error {
 	return nil
 }
 
+func (msg *skyProtoMessage) resetAttrCache() {
+	msg.attrCache = make(map[string]starlark.Value)
+}
+
 func (msg *skyProtoMessage) Attr(name string) (starlark.Value, error) {
 	if attr, ok := msg.attrCache[name]; ok {
 		return attr, nil


### PR DESCRIPTION
This cache allows lookups of stateful attributes (e.g. repeated fields)
to return a value with mutation capability, so that `msg.field.append()`
works as expected.

When the message is mutated from a non-field-specific API such as
`proto.clear()` or `proto.merge()`, the attribute cache was not being
cleared. This caused attribute lookups to return stale state.

Fixes https://github.com/stripe/skycfg/issues/62