### PR TITLE
Generated empty messages without `proto.Clone`.

### DIFF
--- a/internal/go/skycfg/proto_api.go
+++ b/internal/go/skycfg/proto_api.go
@@ -270,7 +270,7 @@ func fnProtoFromText(t *starlark.Thread, fn *starlark.Builtin, args starlark.Tup
 	if !ok {
 		return nil, fmt.Errorf("%s: for parameter 2: got %s, want proto.MessageType", "proto.from_text", msgType.Type())
 	}
-	msg := proto.Clone(protoMsgType.emptyMsg)
+	msg := protoMsgType.emptyMsg()
 	msg.Reset()
 	if err := proto.UnmarshalText(string(value), msg); err != nil {
 		return nil, err
@@ -290,7 +290,7 @@ func fnProtoFromJson(t *starlark.Thread, fn *starlark.Builtin, args starlark.Tup
 	if !ok {
 		return nil, fmt.Errorf("%s: for parameter 2: got %s, want proto.MessageType", "proto.from_json", msgType.Type())
 	}
-	msg := proto.Clone(protoMsgType.emptyMsg)
+	msg := protoMsgType.emptyMsg()
 	msg.Reset()
 	if err := jsonpb.UnmarshalString(string(value), msg); err != nil {
 		return nil, err
@@ -322,7 +322,7 @@ func fnProtoFromYaml(t *starlark.Thread, fn *starlark.Builtin, args starlark.Tup
 	if err != nil {
 		return nil, err
 	}
-	msg := proto.Clone(protoMsgType.emptyMsg)
+	msg := protoMsgType.emptyMsg()
 	msg.Reset()
 	if err := jsonpb.UnmarshalString(string(jsonData), msg); err != nil {
 		return nil, err

--- a/internal/go/skycfg/proto_message_type.go
+++ b/internal/go/skycfg/proto_message_type.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 
 	"github.com/golang/protobuf/descriptor"
-	"github.com/golang/protobuf/proto"
 	descriptor_pb "github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"go.starlark.net/starlark"
 )
@@ -40,20 +39,22 @@ func newMessageType(registry ProtoRegistry, name string) (starlark.Value, error)
 		return nil, fmt.Errorf("Protobuf message type %q not found", name)
 	}
 
-	var emptyMsg descriptor.Message
-	if goType.Kind() == reflect.Ptr {
-		goValue := reflect.New(goType.Elem()).Interface()
-		if iface, ok := goValue.(descriptor.Message); ok {
-			emptyMsg = iface
+	emptyMsg := func() descriptor.Message {
+		if goType.Kind() == reflect.Ptr {
+			goValue := reflect.New(goType.Elem()).Interface()
+			if iface, ok := goValue.(descriptor.Message); ok {
+				return iface
+			}
 		}
+		return nil
 	}
-	if emptyMsg == nil {
+	if emptyMsg() == nil {
 		// Return a slightly useful error in case some clever person has
 		// manually registered a `proto.Message` that doesn't use pointer
 		// receivers.
 		return nil, fmt.Errorf("InternalError: %v is not a generated proto.Message", goType)
 	}
-	fileDesc, msgDesc := descriptor.ForMessage(emptyMsg)
+	fileDesc, msgDesc := descriptor.ForMessage(emptyMsg())
 	mt := &skyProtoMessageType{
 		registry: registry,
 		fileDesc: fileDesc,
@@ -80,7 +81,7 @@ type skyProtoMessageType struct {
 	msgDesc  *descriptor_pb.DescriptorProto
 
 	// An empty protobuf message of the appropriate type.
-	emptyMsg proto.Message
+	emptyMsg func() descriptor.Message
 }
 
 var _ starlark.HasAttrs = (*skyProtoMessageType)(nil)
@@ -97,7 +98,7 @@ func (mt *skyProtoMessageType) Hash() (uint32, error) {
 }
 
 func (mt *skyProtoMessageType) Name() string {
-	return messageTypeName(mt.emptyMsg)
+	return messageTypeName(mt.emptyMsg())
 }
 
 func (mt *skyProtoMessageType) Attr(attrName string) (starlark.Value, error) {
@@ -141,7 +142,7 @@ func (mt *skyProtoMessageType) CallInternal(thread *starlark.Thread, args starla
 		return nil, err
 	}
 
-	wrapper := NewSkyProtoMessage(proto.Clone(mt.emptyMsg))
+	wrapper := NewSkyProtoMessage(mt.emptyMsg())
 
 	// Parse the kwarg set into a map[string]starlark.Value, containing one
 	// entry for each provided kwarg. Keys are the original protobuf field names.


### PR DESCRIPTION
This PR partially fixes #27.

The `resource.Quantity` proto message is generated from a go struct through the `go-to-protobuf` k8s tool. This creates two problems:
* The `Quantity` go struct has unexported fields, which is not cloneable through reflection, but `skycfg` uses `proto.Clone` to create empty messages. This problem is fixed in this PR by creating empty messages through `reflect.New` instead.
* The Quantity go struct doesn’t have any protobuf tag, but `skycfg` uses tags to extract field names. As a result, skycfg doesn’t not recognize `resource.Quantity(string = "1000m")`. To resolve this, you'll need to replace `k8s.io/apimachinery` in `go.mod` with my fork, which adds protobuf tags to the `Quantity` go struct:
```
replace k8s.io/apimachinery => github.com/chhsia0/apimachinery <k8s_version>-quantity-tag
```
where k8s_version can be 1.14, 1.15, 1.16 or 1.17. I'll post a PR to upstream this change.