### PR TITLE
[yaml]: Update YAML parser to yaml.v3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,9 @@ require (
 	github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348
 	go.starlark.net v0.0.0-20190604130855-6ddc71c0ba77
 	gopkg.in/yaml.v2 v2.2.1
+	gopkg.in/yaml.v3 v3.0.0-20200121175148-a6ecf24a6d71
 )
 
 replace github.com/kylelemons/godebug => github.com/jmillikin-stripe/godebug v0.0.0-20180620173319-8279e1966bc1
+
+go 1.13

--- a/go.mod
+++ b/go.mod
@@ -10,5 +10,3 @@ require (
 )
 
 replace github.com/kylelemons/godebug => github.com/jmillikin-stripe/godebug v0.0.0-20180620173319-8279e1966bc1
-
-go 1.13

--- a/go.sum
+++ b/go.sum
@@ -13,3 +13,5 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.1 h1:mUhvW9EsL+naU5Q3cakzfE91YhliOondGd6ZrsDBHQE=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200121175148-a6ecf24a6d71 h1:Xe2gvTZUJpsvOWUnvmL/tmhVBZUmHSvLbMjRj6NUUKo=
+gopkg.in/yaml.v3 v3.0.0-20200121175148-a6ecf24a6d71/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/go/skycfg/yaml_test.go
+++ b/internal/go/skycfg/yaml_test.go
@@ -41,20 +41,20 @@ func TestSkyToYaml(t *testing.T) {
 `,
 		},
 		YamlTestCase{
-			skyExpr: `{"a": 5, 13: 2, "k": {"k2": "v"}}`,
+			skyExpr: `{13: 2, "k": {"k2": "v"}, "a": 5.11}`,
 			expOutput: `13: 2
-a: 5
 k:
   k2: v
+a: 5.11
 `,
 		},
 		YamlTestCase{
-			skyExpr: `[1, 2, 3, "abc", None, 15, True, False, {"k": "v"}]`,
+			skyExpr: `[1, 2, 3, None, "abc", 15, True, False, {"k": "v"}]`,
 			expOutput: `- 1
 - 2
 - 3
-- abc
 - null
+- abc
 - 15
 - true
 - false
@@ -198,8 +198,8 @@ func TestYamlToSky(t *testing.T) {
 		},
 		{
 			name: "negative Int64 key mapped to String",
-			key: starlark.MakeInt64(-2147483649),
-			want:  `"nInt64Key"`,
+			key:  starlark.MakeInt64(-2147483649),
+			want: `"nInt64Key"`,
 		},
 		{
 			name: "Uint key mapped to String",
@@ -230,9 +230,9 @@ func TestYamlToSky(t *testing.T) {
 			if testCase.want != got.String() {
 				t.Error(
 					"Bad return value from yaml.unmarshal",
-					"\nExpected:",
+					"Expected:",
 					testCase.want,
-					"\nGot:",
+					"Got:",
 					got,
 				)
 			}


### PR DESCRIPTION
Migrate to https://github.com/go-yaml/yaml/tree/v3 and don't roundtrip through JSON to support stable order of YAML maps (perviously they would be shuffled due to round-tripping via Go map).

This can also enable support for alias YAML nodes but is not part of this PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stripe/skycfg/72)
<!-- Reviewable:end -->
