### PR TITLE
Fix construction of multiply-nested message types.

### DIFF
--- a/internal/go/skycfg/proto_package.go
+++ b/internal/go/skycfg/proto_package.go
@@ -78,5 +78,5 @@ func (pkg *skyProtoPackage) Attr(attrName string) (starlark.Value, error) {
 			valueMap: ev,
 		}, nil
 	}
-	return newMessageType(registry, fullName)
+	return newMessageType(registry, "", fullName)
 }

--- a/internal/go/skycfg/proto_test.go
+++ b/internal/go/skycfg/proto_test.go
@@ -129,6 +129,50 @@ func TestProtoMessageString(t *testing.T) {
 	}
 }
 
+func TestNestedMessages(t *testing.T) {
+	testPb := `proto.package("skycfg.test_proto").`
+	gogoPb := `gogo_proto.package("skycfg.test_proto").`
+
+	tests := []struct {
+		src     string
+		wantVal string
+	}{
+		{
+			src: testPb + `MessageV2.NestedMessage()`,
+			wantVal: `<skycfg.test_proto.MessageV2.NestedMessage >`,
+		},
+		{
+			src: testPb + `MessageV2.NestedMessage.DoubleNestedMessage()`,
+			wantVal: `<skycfg.test_proto.MessageV2.NestedMessage.DoubleNestedMessage >`,
+		},
+
+		{
+			src: testPb + `MessageV3.NestedMessage()`,
+			wantVal: `<skycfg.test_proto.MessageV3.NestedMessage >`,
+		},
+		{
+			src: testPb + `MessageV3.NestedMessage.DoubleNestedMessage()`,
+			wantVal: `<skycfg.test_proto.MessageV3.NestedMessage.DoubleNestedMessage >`,
+		},
+
+		{
+			src: gogoPb + `MessageGogo.NestedMessage()`,
+			wantVal: `<skycfg.test_proto.MessageGogo.NestedMessage >`,
+		},
+		{
+			src: gogoPb + `MessageGogo.NestedMessage.DoubleNestedMessage()`,
+			wantVal: `<skycfg.test_proto.MessageGogo.NestedMessage.DoubleNestedMessage >`,
+		},
+	}
+	for _, test := range tests {
+		gotVal := skyEval(t, test.src).String()
+		if test.wantVal != gotVal {
+			t.Errorf("eval(%q): expected value %q, got %q", test.src, test.wantVal, gotVal)
+		}
+	}
+
+}
+
 func TestProtoSetDefaultV2(t *testing.T) {
 	val := skyEval(t, `proto.set_defaults(proto.package("skycfg.test_proto").MessageV2())`)
 	gotMsg := val.(*skyProtoMessage).msg

--- a/internal/testdata/test_proto/test_proto_v2.proto
+++ b/internal/testdata/test_proto/test_proto_v2.proto
@@ -39,6 +39,10 @@ message MessageV2 {
 
   message NestedMessage {
     optional string f_string = 1;
+
+    message DoubleNestedMessage {
+      optional string f_string = 1;
+    }
   }
   optional NestedMessage f_nested_submsg = 16;
 

--- a/internal/testdata/test_proto/test_proto_v3.proto
+++ b/internal/testdata/test_proto/test_proto_v3.proto
@@ -41,6 +41,10 @@ message MessageV3 {
 
   message NestedMessage {
     string f_string = 1;
+
+    message DoubleNestedMessage {
+      string f_string = 1;
+    }
   }
   NestedMessage f_nested_submsg = 16;
 

--- a/internal/testdata/test_proto_gogo/test_proto_gogo.proto
+++ b/internal/testdata/test_proto_gogo/test_proto_gogo.proto
@@ -52,6 +52,10 @@ message MessageGogo {
 
   message NestedMessage {
     optional string f_string = 1;
+
+    message DoubleNestedMessage {
+      optional string f_string = 1;
+    }
   }
   optional NestedMessage f_nested_submsg = 16;
 


### PR DESCRIPTION
Given a Protobuf message layout like this:
```protobuf
message A {
  message B {
    message C {
      // ...
    }
  }
}
```

The code for calculating message names was incorrect; it would drop `A.` from the lookup path.

This PR fixes it by recording the package-relative qualified name as a field of `skyProtoMessageType`.

r? @abloom-stripe