### PR TITLE
Add a WithEntryPoint ExecOption

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -6,6 +6,7 @@
 #     Name <email address>
 
 Alexander Pakulov <apakulov@stripe.com>
+Andrew Bloom <abloom@stripe.com>
 Benjamin Yolken <yolken@stripe.com>
 Dmitry Ilyevsky <ilyevsky@gmail.com> # GM Cruise LLC
 Isaac Diamond <idiamond@stripe.com>

--- a/go.mod
+++ b/go.mod
@@ -9,3 +9,5 @@ require (
 )
 
 replace github.com/kylelemons/godebug => github.com/jmillikin-stripe/godebug v0.0.0-20180620173319-8279e1966bc1
+
+go 1.13

--- a/go.mod
+++ b/go.mod
@@ -9,5 +9,3 @@ require (
 )
 
 replace github.com/kylelemons/godebug => github.com/jmillikin-stripe/godebug v0.0.0-20180620173319-8279e1966bc1
-
-go 1.13


### PR DESCRIPTION
Allow overriding the `main` entry point in your skycfg code with another named function as long as its signature is the same.

```python
# skycfg
def not_main(ctx):
    message = test_proto.MessageV2()
    return [message]
```

```go
// go
config.Main(context.Background(), skycfg.WithVars(testCase.vars), skycfg.WithEntryPoint("not_main"))
```