### PR TITLE
Implement starlark.Comparable for enums.

### DIFF
--- a/internal/go/skycfg/proto_enum.go
+++ b/internal/go/skycfg/proto_enum.go
@@ -23,6 +23,7 @@ import (
 
 	descriptor_pb "github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"go.starlark.net/starlark"
+	"go.starlark.net/syntax"
 )
 
 type skyProtoEnumType struct {
@@ -64,6 +65,8 @@ type skyProtoEnumValue struct {
 	value     int32
 }
 
+var _ starlark.Comparable = (*skyProtoEnumValue)(nil)
+
 func (v *skyProtoEnumValue) String() string {
 	return fmt.Sprintf("<%s %s=%d>", v.typeName, v.valueName, v.value)
 }
@@ -72,6 +75,24 @@ func (v *skyProtoEnumValue) Freeze()              {}
 func (v *skyProtoEnumValue) Truth() starlark.Bool { return starlark.True }
 func (v *skyProtoEnumValue) Hash() (uint32, error) {
 	return starlark.MakeInt64(int64(v.value)).Hash()
+}
+
+func (v *skyProtoEnumValue) CompareSameType(op syntax.Token, y starlark.Value, depth int) (bool, error) {
+	other, ok := y.(*skyProtoEnumValue)
+	if !ok {
+		return false, fmt.Errorf("`%v' not enum value", y)
+	}
+
+	eq := (v.typeName == other.typeName) && (v.valueName == other.valueName) && (v.value == other.value)
+
+	switch op {
+	case syntax.EQL:
+		return eq, nil
+	case syntax.NEQ:
+		return !eq, nil
+	default:
+		return false, fmt.Errorf("enums support only `==' and `!=' comparisons, got: %#v", op)
+	}
 }
 
 // Interface for generated enum types.

--- a/internal/go/skycfg/proto_enum.go
+++ b/internal/go/skycfg/proto_enum.go
@@ -78,18 +78,12 @@ func (v *skyProtoEnumValue) Hash() (uint32, error) {
 }
 
 func (v *skyProtoEnumValue) CompareSameType(op syntax.Token, y starlark.Value, depth int) (bool, error) {
-	other, ok := y.(*skyProtoEnumValue)
-	if !ok {
-		return false, fmt.Errorf("`%v' not enum value", y)
-	}
-
-	eq := (v.typeName == other.typeName) && (v.valueName == other.valueName) && (v.value == other.value)
-
+	other := y.(*skyProtoEnumValue)
 	switch op {
 	case syntax.EQL:
-		return eq, nil
+		return v.value == other.value, nil
 	case syntax.NEQ:
-		return !eq, nil
+		return v.value != other.value, nil
 	default:
 		return false, fmt.Errorf("enums support only `==' and `!=' comparisons, got: %#v", op)
 	}

--- a/internal/go/skycfg/proto_test.go
+++ b/internal/go/skycfg/proto_test.go
@@ -1224,3 +1224,33 @@ def fun():
 		}
 	}
 }
+
+func TestProtoEnumEqual(t *testing.T) {
+	val := skyEval(t, `
+proto.package("skycfg.test_proto").ToplevelEnumV2.TOPLEVEL_ENUM_V2_A == proto.package("skycfg.test_proto").ToplevelEnumV2.TOPLEVEL_ENUM_V2_A`)
+	got := val.(starlark.Bool)
+	if !bool(got) {
+		t.Error("Expected equal enums")
+	}
+
+	val = skyEval(t, `
+proto.package("skycfg.test_proto").ToplevelEnumV2.TOPLEVEL_ENUM_V2_A == proto.package("skycfg.test_proto").ToplevelEnumV2.TOPLEVEL_ENUM_V2_B`)
+	got = val.(starlark.Bool)
+	if bool(got) {
+		t.Error("Expected unequal enums")
+	}
+
+	val = skyEval(t, `
+proto.package("skycfg.test_proto").ToplevelEnumV2.TOPLEVEL_ENUM_V2_A != proto.package("skycfg.test_proto").ToplevelEnumV2.TOPLEVEL_ENUM_V2_A`)
+	got = val.(starlark.Bool)
+	if bool(got) {
+		t.Error("Expected equal enums")
+	}
+
+	val = skyEval(t, `
+proto.package("skycfg.test_proto").ToplevelEnumV2.TOPLEVEL_ENUM_V2_A != proto.package("skycfg.test_proto").ToplevelEnumV2.TOPLEVEL_ENUM_V2_B`)
+	got = val.(starlark.Bool)
+	if !bool(got) {
+		t.Error("Expected unequal enums")
+	}
+}


### PR DESCRIPTION
Implement `starlark.Comparable` interface for `skyProtoEnumValue` to handle enum comparison correctly. Only supports `==` and `!=` operations.

Fixes https://github.com/stripe/skycfg/issues/76