### PR TITLE
Export proto package as a starlark value.

### DIFF
--- a/internal/go/skycfg/proto_api.go
+++ b/internal/go/skycfg/proto_api.go
@@ -169,10 +169,7 @@ func (mod *ProtoModule) fnProtoPackage(t *starlark.Thread, fn *starlark.Builtin,
 	if err := starlark.UnpackPositionalArgs("proto.package", args, kwargs, 1, &packageName); err != nil {
 		return nil, err
 	}
-	return &skyProtoPackage{
-		registry: mod.Registry,
-		name:     packageName,
-	}, nil
+	return NewSkyProtoPackage(mod.Registry, packageName), nil
 }
 
 func wantSingleProtoMessage(fnName string, args starlark.Tuple, kwargs []starlark.Tuple, msg **skyProtoMessage) error {

--- a/internal/go/skycfg/proto_package.go
+++ b/internal/go/skycfg/proto_package.go
@@ -34,11 +34,12 @@ func (*defaultProtoRegistry) UnstableEnumValueMap(name string) map[string]int32 
 	return proto.EnumValueMap(name)
 }
 
-// NewProtoPackage creates a Starlark value representing a named Protobuf package.
+// NewSkyProtoPackage creates a Starlark value representing a named Protobuf
+// package.
 //
 // Protobuf packagess are conceptually similar to a C++ namespace or Ruby
 // module, in that they're aggregated from multiple .proto source files.
-func newProtoPackage(registry ProtoRegistry, name string) starlark.Value {
+func NewSkyProtoPackage(registry ProtoRegistry, name string) starlark.Value {
 	return &skyProtoPackage{
 		registry: registry,
 		name:     name,

--- a/skycfg.go
+++ b/skycfg.go
@@ -90,6 +90,12 @@ func AsProtoMessage(v starlark.Value) (proto.Message, bool) {
 	return impl.ToProtoMessage(v)
 }
 
+// NewProtoPackage returns a Starlark value representing the given Protobuf
+// package. It can be added to global symbols when loading a Skycfg config file.
+func NewProtoPackage(r unstableProtoRegistry, name string) starlark.Value {
+	return impl.NewSkyProtoPackage(r, name)
+}
+
 // A Config is a Skycfg config file that has been fully loaded and is ready
 // for execution.
 type Config struct {


### PR DESCRIPTION
This would allow users to create proto packages as globals in their own Starlark runtime.