### PR TITLE
Protobuf api V2: add protoMessage, merge and autoboxing wrapperspb 

### DIFF
--- a/go/protomodule/BUILD
+++ b/go/protomodule/BUILD
@@ -3,10 +3,12 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "protomodule",
     srcs = [
+        "merge.go",
         "protomodule.go",
         "protomodule_enum.go",
         "protomodule_list.go",
         "protomodule_map.go",
+        "protomodule_message.go",
         "protomodule_message_type.go",
         "protomodule_package.go",
         "type_conversions.go",
@@ -24,19 +26,28 @@ go_library(
         "@org_golang_google_protobuf//proto",
         "@org_golang_google_protobuf//reflect/protoreflect",
         "@org_golang_google_protobuf//reflect/protoregistry",
+        "@org_golang_google_protobuf//types/dynamicpb",
         "@org_golang_google_protobuf//types/known/anypb",
+        "@org_golang_google_protobuf//types/known/wrapperspb",
     ],
 )
 
 go_test(
     name = "protomodule_test",
-    srcs = ["protomodule_test.go"],
+    srcs = [
+        "protomodule_test.go",
+    ],
     embed = [":protomodule"],
     deps = [
+        "//:skycfg",
+        "//internal/go/skycfg",
         "//internal/testdata/test_proto:test_proto_go_proto",
         "@net_starlark_go//resolve",
         "@net_starlark_go//starlark",
         "@net_starlark_go//starlarkstruct",
+        "@net_starlark_go//syntax",
         "@org_golang_google_protobuf//reflect/protoregistry",
+        "@org_golang_google_protobuf//types/descriptorpb",
+        "@org_golang_google_protobuf//types/known/anypb",
     ],
 )

--- a/go/protomodule/merge.go
+++ b/go/protomodule/merge.go
@@ -1,0 +1,97 @@
+// Copyright 2021 The Skycfg Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package protomodule
+
+import (
+	"fmt"
+
+	"go.starlark.net/starlark"
+)
+
+// Implements proto.merge merging src into dst, returning merged value
+func mergeField(dst, src starlark.Value) (starlark.Value, error) {
+	if dst == nil {
+		return src, nil
+	}
+	if src == nil {
+		return dst, nil
+	}
+
+	if dst.Type() != src.Type() {
+		return nil, mergeError(dst, src)
+	}
+
+	switch dst := dst.(type) {
+	case *protoRepeated:
+		if src, ok := src.(*protoRepeated); ok {
+			newList := newProtoRepeated(dst.fieldDesc)
+
+			err := newList.Extend(dst)
+			if err != nil {
+				return nil, err
+			}
+
+			err = newList.Extend(src)
+			if err != nil {
+				return nil, err
+			}
+
+			return newList, nil
+		}
+		return nil, mergeError(dst, src)
+	case *protoMap:
+		if src, ok := src.(*protoMap); ok {
+			newMap := newProtoMap(dst.mapKey, dst.mapValue)
+
+			for _, item := range dst.Items() {
+				err := newMap.SetKey(item[0], item[1])
+				if err != nil {
+					return nil, err
+				}
+			}
+
+			for _, item := range src.Items() {
+				err := newMap.SetKey(item[0], item[1])
+				if err != nil {
+					return nil, err
+				}
+			}
+
+			return newMap, nil
+		}
+		return nil, mergeError(dst, src)
+	case *protoMessage:
+		if src, ok := src.(*protoMessage); ok {
+			newMessage, err := NewMessage(dst.msg)
+			if err != nil {
+				return nil, err
+			}
+
+			newMessage.Merge(dst)
+			newMessage.Merge(src)
+
+			return newMessage, nil
+		}
+		return nil, mergeError(dst, src)
+	default:
+		return src, nil
+	}
+}
+
+func mergeError(dst, src starlark.Value) error {
+	return fmt.Errorf("MergeError: Cannot merge protobufs of different types: Merge(%s, %s)", dst.Type(), src.Type())
+}

--- a/go/protomodule/merge.go
+++ b/go/protomodule/merge.go
@@ -37,56 +37,62 @@ func mergeField(dst, src starlark.Value) (starlark.Value, error) {
 
 	switch dst := dst.(type) {
 	case *protoRepeated:
-		if src, ok := src.(*protoRepeated); ok {
-			newList := newProtoRepeated(dst.fieldDesc)
-
-			err := newList.Extend(dst)
-			if err != nil {
-				return nil, err
-			}
-
-			err = newList.Extend(src)
-			if err != nil {
-				return nil, err
-			}
-
-			return newList, nil
+		src, ok := src.(*protoRepeated)
+		if !ok {
+			return nil, mergeError(dst, src)
 		}
-		return nil, mergeError(dst, src)
+
+		newList := newProtoRepeated(dst.fieldDesc)
+
+		err := newList.Extend(dst)
+		if err != nil {
+			return nil, err
+		}
+
+		err = newList.Extend(src)
+		if err != nil {
+			return nil, err
+		}
+
+		return newList, nil
 	case *protoMap:
-		if src, ok := src.(*protoMap); ok {
-			newMap := newProtoMap(dst.mapKey, dst.mapValue)
-
-			for _, item := range dst.Items() {
-				err := newMap.SetKey(item[0], item[1])
-				if err != nil {
-					return nil, err
-				}
-			}
-
-			for _, item := range src.Items() {
-				err := newMap.SetKey(item[0], item[1])
-				if err != nil {
-					return nil, err
-				}
-			}
-
-			return newMap, nil
+		src, ok := src.(*protoMap)
+		if !ok {
+			return nil, mergeError(dst, src)
 		}
-		return nil, mergeError(dst, src)
-	case *protoMessage:
-		if src, ok := src.(*protoMessage); ok {
-			newMessage, err := NewMessage(dst.msg)
+
+		newMap := newProtoMap(dst.mapKey, dst.mapValue)
+
+		for _, item := range dst.Items() {
+			err := newMap.SetKey(item[0], item[1])
 			if err != nil {
 				return nil, err
 			}
-
-			newMessage.Merge(dst)
-			newMessage.Merge(src)
-
-			return newMessage, nil
 		}
-		return nil, mergeError(dst, src)
+
+		for _, item := range src.Items() {
+			err := newMap.SetKey(item[0], item[1])
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		return newMap, nil
+	case *protoMessage:
+		src, ok := src.(*protoMessage)
+		if !ok {
+			return nil, mergeError(dst, src)
+		}
+
+		newMessage, err := NewMessage(dst.msg)
+		if err != nil {
+			return nil, err
+		}
+
+		newMessage.Merge(dst)
+		newMessage.Merge(src)
+
+		return newMessage, nil
 	default:
 		return src, nil
 	}

--- a/go/protomodule/protomodule_list.go
+++ b/go/protomodule/protomodule_list.go
@@ -1,4 +1,4 @@
-// Copyright 2020 The Skycfg Authors.
+// Copyright 2021 The Skycfg Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/go/protomodule/protomodule_map.go
+++ b/go/protomodule/protomodule_map.go
@@ -1,4 +1,4 @@
-// Copyright 2020 The Skycfg Authors.
+// Copyright 2021 The Skycfg Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/go/protomodule/protomodule_message.go
+++ b/go/protomodule/protomodule_message.go
@@ -1,0 +1,370 @@
+// Copyright 2021 The Skycfg Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package protomodule
+
+import (
+	"fmt"
+	"sort"
+
+	"go.starlark.net/starlark"
+	"go.starlark.net/syntax"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/encoding/prototext"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+// NewMessage returns a Starlark value representing the given Protobuf
+// message. It can be returned back to a proto.Message() via AsProtoMessage().
+//
+// NewMessage copies the input proto.Message and therefore does not modify it
+func NewMessage(msg proto.Message) (*protoMessage, error) {
+	msgDesc := msg.ProtoReflect().Descriptor()
+
+	fields := make(map[string]starlark.Value)
+
+	// Copy any existing set fields
+	msgReflect := msg.ProtoReflect()
+	msgReflect.Range(func(fd protoreflect.FieldDescriptor, v protoreflect.Value) bool {
+		if isFieldSet(v, fd) {
+			starlarkValue, err := valueToStarlark(v, fd)
+			if err != nil {
+				// Skip field rather than erroring to maintain skycfg.NewProtoMessage api
+				return true
+			}
+			fields[string(fd.Name())] = starlarkValue
+
+		}
+		return true
+	})
+
+	// Clone and reset the input msg to ensure no mutations
+	cloned := proto.Clone(msg)
+	proto.Reset(cloned)
+
+	return &protoMessage{
+		msg:     cloned,
+		msgDesc: msgDesc,
+		fields:  fields,
+		frozen:  false,
+	}, nil
+}
+
+// AsProtoMessage returns a Protobuf message underlying the given Starlark
+// value, which must have been created by NewProtoMessage(). Returns
+// (_, false) if the value is not a valid message.
+func AsProtoMessage(v starlark.Value) (proto.Message, bool) {
+	if msg, ok := v.(*protoMessage); ok {
+		return msg.toProtoMessage(), true
+	}
+	return nil, false
+}
+
+// protoMessage exposes an underlying protobuf message as a starlark.Value
+//
+// Internally protoMessage tracks the message state on the `fields` map. Values
+// are stored as starlark.Value through execution and only converted into a
+// proto.Message through AsProtoMessage. Any fields set to starlark.None or the
+// default field value will be ignored when returning to a protobuf.Message
+type protoMessage struct {
+	// A copy of the underlying is stored so AsProtoMessage can construct a new object
+	msg     proto.Message
+	msgDesc protoreflect.MessageDescriptor
+	fields  map[string]starlark.Value
+	frozen  bool
+}
+
+var _ starlark.Value = (*protoMessage)(nil)
+var _ starlark.HasAttrs = (*protoMessage)(nil)
+var _ starlark.HasSetField = (*protoMessage)(nil)
+var _ starlark.Comparable = (*protoMessage)(nil)
+
+func (msg *protoMessage) String() string {
+	return fmt.Sprintf("<%s %s>", msg.Type(), (prototext.MarshalOptions{Multiline: false}).Format(msg.toProtoMessage()))
+}
+func (msg *protoMessage) Type() string         { return string(msg.msgDesc.FullName()) }
+func (msg *protoMessage) Truth() starlark.Bool { return starlark.True }
+func (msg *protoMessage) Hash() (uint32, error) {
+	return 0, fmt.Errorf("unhashable type: %s", msg.Type())
+}
+
+func (msg *protoMessage) Freeze() {
+	if !msg.frozen {
+		msg.frozen = true
+		for _, field := range msg.fields {
+			field.Freeze()
+		}
+	}
+}
+
+// Clear all fields to unset
+func (msg *protoMessage) Clear() error {
+	if err := msg.CheckMutable("clear"); err != nil {
+		return err
+	}
+
+	msg.fields = make(map[string]starlark.Value)
+
+	return nil
+}
+
+func (msg *protoMessage) CheckMutable(verb string) error {
+	if msg.frozen {
+		return fmt.Errorf("cannot %s frozen message", verb)
+	}
+	return nil
+}
+
+func (msg *protoMessage) CompareSameType(op syntax.Token, y starlark.Value, depth int) (bool, error) {
+	other, ok := y.(*protoMessage)
+	if !ok {
+		return false, nil
+	}
+
+	switch op {
+	case syntax.EQL:
+		eql := proto.Equal(msg.toProtoMessage(), other.toProtoMessage())
+		return eql, nil
+	case syntax.NEQ:
+		eql := proto.Equal(msg.toProtoMessage(), other.toProtoMessage())
+		return !eql, nil
+	default:
+		return false, fmt.Errorf("Only == and != operations are supported on protobufs, found %s", op.String())
+	}
+}
+
+func (msg *protoMessage) MarshalJSON() ([]byte, error) {
+	jsonData, err := (protojson.MarshalOptions{
+		UseProtoNames: true,
+	}).Marshal(msg.toProtoMessage())
+	if err != nil {
+		return nil, err
+	}
+	return []byte(jsonData), nil
+}
+
+func (msg *protoMessage) Attr(name string) (starlark.Value, error) {
+	// If a value has already been set on msg, return it
+	if val, ok := msg.fields[name]; ok {
+		return val, nil
+	}
+
+	fieldDesc := getFieldDescriptor(msg.msgDesc, name)
+	if fieldDesc == nil {
+		return starlark.None, fmt.Errorf("AttributeError: `%s' value has no field %q", msg.Type(), name)
+	}
+
+	// Given field name exists but has not been set, return a default value
+	val := fieldDesc.Default()
+
+	starlarkValue, err := valueToStarlark(val, fieldDesc)
+	if err != nil {
+		return starlark.None, err
+	}
+
+	// For non-scalar values, set the value on access even if it is unset so
+	// use without initialization works.
+	//
+	// Example:
+	//   msg = MyProtoMessage()
+	//   msg.repeated_field.append("a")
+	//   # msg.repeated_field should be ["a"]
+	if fieldDesc.IsList() || fieldDesc.IsMap() || fieldDesc.Kind() == protoreflect.MessageKind {
+		msg.SetField(name, starlarkValue)
+	}
+
+	return starlarkValue, nil
+}
+
+func (msg *protoMessage) AttrNames() []string {
+	return fieldNames(msg.msgDesc)
+}
+
+func fieldNames(msgDesc protoreflect.MessageDescriptor) []string {
+	out := []string{}
+	fields := msgDesc.Fields()
+	for i := 0; i < fields.Len(); i++ {
+		fieldName := string(fields.Get(i).Name())
+		out = append(out, fieldName)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func (msg *protoMessage) SetField(name string, val starlark.Value) error {
+	fieldDesc := getFieldDescriptor(msg.msgDesc, name)
+	if fieldDesc == nil {
+		return fmt.Errorf("AttributeError: `%s' value has no field %q", msg.Type(), name)
+	}
+
+	if err := msg.CheckMutable("set field of"); err != nil {
+		return err
+	}
+
+	// Convert starlark.List and starlark.Dict on assignment
+	if fieldDesc.IsList() {
+		if starlarkListVal, ok := val.(*starlark.List); ok {
+			// Convert starlark.List to protoRepeated
+			list, err := newProtoRepeatedFromList(fieldDesc, starlarkListVal)
+			if err != nil {
+				return err
+			}
+
+			val = list
+		}
+	} else if fieldDesc.IsMap() {
+		if starlarkDictVal, ok := val.(*starlark.Dict); ok {
+			// Convert stalark.Map into protoMap
+			mapVal, err := newProtoMapFromDict(fieldDesc.MapKey(), fieldDesc.MapValue(), starlarkDictVal)
+			if err != nil {
+				return err
+			}
+
+			val = mapVal
+		}
+	}
+
+	// Allow using msg_field = None to unset a scalar message field
+	if fieldDesc.Kind() == protoreflect.MessageKind && val == starlark.None && !fieldDesc.IsList() && !fieldDesc.IsMap() {
+		delete(msg.fields, name)
+		return nil
+	}
+
+	// If valueFromStarlark returns an error, the val cannot be assigned to the field
+	_, err := valueFromStarlark(msg.msg.ProtoReflect(), fieldDesc, val)
+	if err != nil {
+		return err
+	}
+
+	// Clear other oneof
+	oneof := fieldDesc.ContainingOneof()
+	if oneof != nil {
+		fields := oneof.Fields()
+		for i := 0; i < fields.Len(); i++ {
+			delete(msg.fields, string(fields.Get(i).Name()))
+		}
+	}
+
+	msg.fields[name] = val
+
+	return nil
+}
+
+// Applies default values for proto2 fields with defaults that are not already set
+func (msg *protoMessage) SetDefaults() error {
+	if err := msg.CheckMutable("set field defaults of"); err != nil {
+		return err
+	}
+
+	for _, fieldName := range fieldNames(msg.msgDesc) {
+		fieldDesc := getFieldDescriptor(msg.msgDesc, fieldName)
+		if fieldDesc == nil {
+			continue
+		}
+
+		// Already set, do not set default
+		if _, ok := msg.fields[fieldName]; ok {
+			continue
+		}
+
+		if !fieldDesc.HasDefault() {
+			continue
+		}
+
+		val, err := valueToStarlark(fieldDesc.Default(), fieldDesc)
+		if err != nil {
+			return err
+		}
+
+		msg.SetField(fieldName, val)
+	}
+
+	return nil
+}
+
+// Merges values from other into msg following proto.Merge logic
+func (msg *protoMessage) Merge(other *protoMessage) error {
+	if msg.Type() != other.Type() {
+		return fmt.Errorf("Cannot merge protobufs of different types: Merge(%s, %s) ", msg.Type(), other.Type())
+	}
+
+	if err := msg.CheckMutable("merge"); err != nil {
+		return err
+	}
+
+	for fieldName, val := range other.fields {
+		fieldDesc := getFieldDescriptor(msg.msgDesc, fieldName)
+		if fieldDesc == nil {
+			continue
+		}
+
+		merged, err := mergeField(msg.fields[fieldName], val)
+		if err != nil {
+			return err
+		}
+
+		msg.SetField(fieldName, merged)
+	}
+
+	return nil
+}
+
+// Construct a new instance of msg.msg and set each field on msg.fields
+func (msg *protoMessage) toProtoMessage() proto.Message {
+	out := proto.Clone(msg.msg)
+	proto.Reset(out)
+
+	// All entries in msg.fields should exist as fields on the message, and
+	// the values be the corresponding type, checked in SetField
+	for fieldName, val := range msg.fields {
+		fieldDesc := getFieldDescriptor(msg.msgDesc, fieldName)
+		if fieldDesc == nil {
+			continue
+		}
+
+		protoValue, err := valueFromStarlark(msg.msg.ProtoReflect(), fieldDesc, val)
+		if err != nil {
+			continue
+		}
+
+		out.ProtoReflect().Set(fieldDesc, protoValue)
+	}
+
+	return out
+}
+
+func getFieldDescriptor(msgDesc protoreflect.MessageDescriptor, fieldName string) protoreflect.FieldDescriptor {
+	fields := msgDesc.Fields()
+	for i := 0; i < fields.Len(); i++ {
+		field := fields.Get(i)
+		if fieldName == string(field.Name()) {
+			return field
+		}
+	}
+
+	return nil
+}
+
+// Return if a value is not the default
+func isFieldSet(v protoreflect.Value, fieldDesc protoreflect.FieldDescriptor) bool {
+	switch fieldDesc.Kind() {
+	case protoreflect.BytesKind:
+		return len(v.Bytes()) != 0
+	default:
+		return v.Interface() != fieldDesc.Default().Interface()
+	}
+}

--- a/go/protomodule/protomodule_message.go
+++ b/go/protomodule/protomodule_message.go
@@ -33,12 +33,11 @@ import (
 //
 // NewMessage copies the input proto.Message and therefore does not modify it
 func NewMessage(msg proto.Message) (*protoMessage, error) {
-	msgDesc := msg.ProtoReflect().Descriptor()
+	msgReflect := msg.ProtoReflect()
 
 	fields := make(map[string]starlark.Value)
 
 	// Copy any existing set fields
-	msgReflect := msg.ProtoReflect()
 	msgReflect.Range(func(fd protoreflect.FieldDescriptor, v protoreflect.Value) bool {
 		if isFieldSet(v, fd) {
 			starlarkValue, err := valueToStarlark(v, fd)
@@ -58,7 +57,7 @@ func NewMessage(msg proto.Message) (*protoMessage, error) {
 
 	return &protoMessage{
 		msg:     cloned,
-		msgDesc: msgDesc,
+		msgDesc: msgReflect.Descriptor(),
 		fields:  fields,
 		frozen:  false,
 	}, nil

--- a/go/protomodule/protomodule_package.go
+++ b/go/protomodule/protomodule_package.go
@@ -1,4 +1,4 @@
-// Copyright 2020 The Skycfg Authors.
+// Copyright 2021 The Skycfg Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/go/protomodule/type_conversions.go
+++ b/go/protomodule/type_conversions.go
@@ -303,24 +303,6 @@ func maybeConvertToWrapper(fieldDesc protoreflect.FieldDescriptor, val starlark.
 			}
 			return nil, fmt.Errorf("ValueError: value %v is not exactly representable as type `int64'.", val)
 		}
-	case UInt32ValueType:
-		switch val := val.(type) {
-		case starlark.Int:
-			uint64Val, ok := val.Uint64()
-			if ok && uint64Val <= math.MaxUint32 {
-				return NewMessage(&wrapperspb.UInt32Value{Value: uint32(uint64Val)})
-			}
-			return nil, fmt.Errorf("ValueError: value %v is not exactly representable as type `uint32'.", val)
-		}
-	case UInt64ValueType:
-		switch val := val.(type) {
-		case starlark.Int:
-			uint64Val, ok := val.Uint64()
-			if ok {
-				return NewMessage(&wrapperspb.UInt64Value{Value: uint64Val})
-			}
-			return nil, fmt.Errorf("ValueError: value %v is not exactly representable as type `uint64'.", val)
-		}
 	}
 	return nil, nil
 }


### PR DESCRIPTION
## Summary
This PR adds the remaining type implementation

- `protoMessage` matches https://github.com/stripe/skycfg/blob/trunk/internal/go/skycfg/proto_message.go
- `maybeConvertToWrapper` copies https://github.com/stripe/skycfg/blob/34104506579982852541ef96cef964e179fa767b/internal/go/skycfg/proto_message.go#L368
- `merge` is an implementation of `proto.Merge` 
 

## Implementation differences
The main implementation differences here is the new implementation does not store values on the underlying proto.Message, which is only used as a type to later instantiate when using `toProtoMessage`. All the values are stored only on the `fields` map (which is similar to the `attrCache`) from before but the old implementation attempted to keep both `msg` and `attrCache` in sync, producing a lot of extra code and some weird edge case bugs.

This means that `NewMessage` will not mutate the incoming proto message. This is mostly an internal detail except when passing in global values into skycfg -- the evaluated starlark will no longer be able to mutate incoming global variables. IMO this is a good thing, as it's surprising behavior, and a user can always fetch the updated value with `AsProtoMessage`

Example: 
```go
msg := &pb.MessageV2{}
globals := starlark.StringDict{
	"msg": protomodule.NewMessage(msg),
}
_, err := starlark.Eval(&starlark.Thread{}, "", test.src, globals)
```

In the old implementation, `msg` is directly mutated, so `starlark.Eval` can cause a side effect. This means repeatedly running `eval` can produce different results.

In the new implementation, `msg` is unchanged, and the user can use the following to extract the changed global if they wish
```
wrapped := protomodule.NewMessage(msg)
globals := starlark.StringDict{
	"msg": wrapped,
}
_, err := starlark.Eval(&starlark.Thread{}, "", test.src, globals)
out, err := AsProtoMessage(wrapped)
```

## Tests
This is all tested on https://github.com/stripe/skycfg/tree/seena/protobuf-api-v2 but am not adding the tests as part of this PR as they involve making skycfg use `*protoMessage` in place of the legacy `*skyProtoMessage` -- this is the switch from old to new implementation, and I thought it would be better to separate that into it's own PR, since again this pr is mostly boilerplate