### PR TITLE
Support passing in variables into tests

### DIFF
--- a/internal/go/skycfg/skycfg_test.go
+++ b/internal/go/skycfg/skycfg_test.go
@@ -408,7 +408,7 @@ func TestSkycfgTesting(t *testing.T) {
 
 	tests := config.Tests()
 	if len(tests) != len(cases) {
-		t.Error("Expected %d tests but found", len(cases), len(tests))
+		t.Error("Expected %d tests but found %d", len(cases), len(tests))
 	}
 
 	for _, test := range tests {

--- a/skycfg.go
+++ b/skycfg.go
@@ -450,7 +450,7 @@ type fnTestOption func(*testOptions)
 
 func (fn fnTestOption) applyTest(opts *testOptions) { fn(opts) }
 
-// WithVars adds key:value pairs to the ctx.vars dict passed to tests
+// WithTestVars adds key:value pairs to the ctx.vars dict passed to tests
 func WithTestVars(vars starlark.StringDict) TestOption {
 	return fnTestOption(func(opts *testOptions) {
 		for key, value := range vars {


### PR DESCRIPTION
## Summary
Add option to pass in variables into executed tests.

Skycfg supports passing in variables during evaluation, but does not have a similar option to do so when evaluating tests. This works fine for tests on helper functions (where you'd have the caller pass relevant values as parameters rather than accessing the global `ctx.vars` directly) but meant you can't test the output of skycfg evaluation.

For example, if I wanted to assert that my proto's `f_string` is only 100 characters long:

```
def main(ctx):
    msg = MessageV3()
    msg.f_string = "hello, " + ctx.vars["name"]
    return [msg]

def test_main(ctx):
    msg = main(ctx)[0]
    ctx.assert(len(main) < 100)
```

Previously this would fail when running `test_main` because `ctx.vars["name"]` is not available. With this pr, it is possible to pass in the same variables when running tests.

## Tests
Updated tests to skycfg_test to consider this case