### PR TITLE
Protobuf API V2: compatibility fixes

### DIFF
--- a/go/protomodule/protomodule_message.go
+++ b/go/protomodule/protomodule_message.go
@@ -238,7 +238,7 @@ func (msg *protoMessage) SetField(name string, val starlark.Value) error {
 	}
 
 	// Allow using msg_field = None to unset a scalar message field
-	if fieldDesc.Kind() == protoreflect.MessageKind && val == starlark.None && !fieldDesc.IsList() && !fieldDesc.IsMap() {
+	if fieldAllowsNone(fieldDesc) && val == starlark.None {
 		delete(msg.fields, name)
 		return nil
 	}
@@ -366,4 +366,8 @@ func isFieldSet(v protoreflect.Value, fieldDesc protoreflect.FieldDescriptor) bo
 	default:
 		return v.Interface() != fieldDesc.Default().Interface()
 	}
+}
+
+func fieldAllowsNone(fieldDesc protoreflect.FieldDescriptor) bool {
+	return fieldDesc.Kind() == protoreflect.MessageKind && !fieldDesc.IsList() && !fieldDesc.IsMap()
 }

--- a/go/protomodule/protomodule_message.go
+++ b/go/protomodule/protomodule_message.go
@@ -369,5 +369,5 @@ func isFieldSet(v protoreflect.Value, fieldDesc protoreflect.FieldDescriptor) bo
 }
 
 func fieldAllowsNone(fieldDesc protoreflect.FieldDescriptor) bool {
-	return fieldDesc.Kind() == protoreflect.MessageKind && !fieldDesc.IsList() && !fieldDesc.IsMap()
+	return (fieldDesc.Kind() == protoreflect.MessageKind && !fieldDesc.IsList() && !fieldDesc.IsMap()) || fieldDesc.Syntax() == protoreflect.Proto2
 }

--- a/go/protomodule/type_conversions.go
+++ b/go/protomodule/type_conversions.go
@@ -327,8 +327,14 @@ func typeError(fieldDesc protoreflect.FieldDescriptor, val starlark.Value, scala
 		}
 	}
 
-	return fmt.Errorf("TypeError: value %s (type %q) can't be assigned to type %q.",
-		val.String(), val.Type(), expectedType,
+	// Add special error message for = None not allowed in proto3
+	proto3SpecialCase := ""
+	if scalar && val == starlark.None {
+		proto3SpecialCase = " in proto3 mode"
+	}
+
+	return fmt.Errorf("TypeError: value %s (type %q) can't be assigned to type %q%s.",
+		val.String(), val.Type(), expectedType, proto3SpecialCase,
 	)
 }
 

--- a/skycfg.go
+++ b/skycfg.go
@@ -197,12 +197,22 @@ func UnstablePredeclaredModules(r unstableProtoRegistryV2) starlark.StringDict {
 	return starlark.StringDict{
 		"fail":   assertmodule.Fail,
 		"hash":   hashmodule.NewModule(),
-		"json":   starlarkjson.Module,
+		"json":   newJsonModule(),
 		"proto":  UnstableProtoModule(r),
 		"struct": starlark.NewBuiltin("struct", starlarkstruct.Make),
 		"yaml":   newYamlModule(),
 		"url":    urlmodule.NewModule(),
 	}
+}
+
+func newJsonModule() starlark.Value {
+	module := starlarkjson.Module
+
+	// Aliases for compatibility with pre-v1.0 Skycfg API.
+	module.Members["marshal"] = module.Members["encode"]
+	module.Members["unmarshal"] = module.Members["decode"]
+
+	return module
 }
 
 func newYamlModule() starlark.Value {


### PR DESCRIPTION
## Summary
Two fixes to maintain compatibility with the old implementation

- **Add json module members for compat** (852f982):
  `json.marshal` became `json.encode`. Added these aliases back like we do for `yamlModule`
- **Allow constructing message maps with None** (416b96c): 
  Skycfg previously allowed setting proto2 message values with None, effectively unsetting them. For maps, this set them to be nil, so
```python
# skycfg
msg.map_submsg = { 
  "a": None
}
```
became
```go
&pb.MessageV2{
  map_submsg: map[string]*pb.MessageV2{
    "a": nil,
  }
}
```
With protoreflect, `map.Set` only accepts a `protoreflect.Value` https://pkg.go.dev/google.golang.org/protobuf/reflect/protoreflect#Map.Set (a struct, cannot be nil) so my two options are 1) create an empty `&pb.MessageV2{}` or treat `None` as not setting the key. I went with the latter, to make it behave like `protoMessage` but neither option seems _great_

- **Allow set to None in proto2 mode for scalar values** (873051b): this adds back the behavior from https://github.com/stripe/skycfg/blob/e785c6f705dd143a6756f2a0f56005ae824962d4/internal/go/skycfg/proto_test.go#L1069 and  https://github.com/stripe/skycfg/blob/e785c6f705dd143a6756f2a0f56005ae824962d4/internal/go/skycfg/proto_test.go#L870

## Tests
I added a test for compatibility 