### PR TITLE
Add tests to ensure no copy on assignment, fix map

### DIFF
--- a/go/protomodule/protomodule_map.go
+++ b/go/protomodule/protomodule_map.go
@@ -74,6 +74,16 @@ func newProtoMapFromDict(mapKey protoreflect.FieldDescriptor, mapValue protorefl
 		}
 	}
 
+	// Remove any None values from map, see SetKey for compability behavior
+	for _, item := range d.Items() {
+		if item[1] == starlark.None {
+			_, _, err := d.Delete(item[0])
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
 	return out, nil
 }
 

--- a/go/protomodule/protomodule_map.go
+++ b/go/protomodule/protomodule_map.go
@@ -60,11 +60,15 @@ func newProtoMapFromDict(mapKey protoreflect.FieldDescriptor, mapValue protorefl
 	out := &protoMap{
 		mapKey:   mapKey,
 		mapValue: mapValue,
-		dict:     starlark.NewDict(d.Len()),
+		dict:     d,
 	}
 
+	// SetKey is used to typecheck fields appropriately but done on a temporary object
+	// so that the underlying out.dict still has a reference to the given
+	// dict rather than copying
+	tmpMap := newProtoMap(mapKey, mapValue)
 	for _, item := range d.Items() {
-		err := out.SetKey(item[0], item[1])
+		err := tmpMap.SetKey(item[0], item[1])
 		if err != nil {
 			return nil, err
 		}

--- a/go/protomodule/protomodule_map.go
+++ b/go/protomodule/protomodule_map.go
@@ -74,7 +74,7 @@ func newProtoMapFromDict(mapKey protoreflect.FieldDescriptor, mapValue protorefl
 		}
 	}
 
-	// Remove any None values from map, see SetKey for compability behavior
+	// Remove any None values from map, see SetKey for compatibility behavior
 	for _, item := range d.Items() {
 		if item[1] == starlark.None {
 			_, _, err := d.Delete(item[0])

--- a/go/protomodule/protomodule_message_test.go
+++ b/go/protomodule/protomodule_message_test.go
@@ -1030,6 +1030,29 @@ def fun():
 	if !checkError(err, wantErr) {
 		t.Fatalf("eval: expected error %v, got %v", wantErr, err)
 	}
+
+	// An odd resulting behavior of both ensuring assignment does not copy
+	// and setting to None deletes is that assignment can mutate a raw starlark dict
+	// This is not ideal but this test is here to just document the behavior
+	val, err = evalFunc(`
+def fun():
+    pb = proto.package("skycfg.test_proto")
+    a = {
+        "ka": "va",
+        "ba": None,
+    }
+    msg = pb.MessageV2(
+	map_string = a
+    )
+    return a
+`, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := `{"ka": "va"}`
+	if want != val.String() {
+		t.Fatalf("Result differed\nwant: %s\ngot : %s", want, val.String())
+	}
 }
 
 func TestUnsetProto2Fields(t *testing.T) {


### PR DESCRIPTION
## Summary
This PR adds tests to ensure `protoMap`, `protoList` and `protoMessage` are not copying values on assignment and corrects `protoMap`. Yesterday I learned Skycfg previously did this _sometimes_, e.g. in the old implementation this would happen:

```python
# v0.1.0 Behavior
msg1.r_string = ["a","b"]
a = msg1.r_string
msg2.r_string = msg1.r_string
a.append("c")

# a = [a, b, c]
# msg1.r_string = [a, b, c]
# msg2.r_string = [a, b]
```
(https://github.com/stripe/skycfg/blob/677b39f98fc6399c738a295fc3d77690ffda54c7/internal/go/skycfg/proto_message.go#L518)

The re-implementation fixed this for lists but not for maps incidentally so I added tests to make this behavior explicit. AFAICT from testing starlark, starlark does not copy on assignment for lists and dictionaries (like python) and seems to be what is described in https://github.com/bazelbuild/starlark/blob/master/spec.md#value-concepts

## Tests
Added tests when assigning skycfg and starlark values into a skycfg object