### PR TITLE
Correct switch from newJsonModule to starlarkjson.Module

### DIFF
--- a/skycfg.go
+++ b/skycfg.go
@@ -197,7 +197,7 @@ func UnstablePredeclaredModules(r unstableProtoRegistryV2) starlark.StringDict {
 	return starlark.StringDict{
 		"fail":   assertmodule.Fail,
 		"hash":   hashmodule.NewModule(),
-		"json":   starlarkjson.Module,
+		"json":   newJsonModule(),
 		"proto":  UnstableProtoModule(r),
 		"struct": starlark.NewBuiltin("struct", starlarkstruct.Make),
 		"yaml":   newYamlModule(),


### PR DESCRIPTION
## Summary
#96 contains a mistake https://github.com/stripe/skycfg/pull/96/files#diff-4736be5fbaa9c6db5622bcda67b00679048806105921368e74f32c5a95aaea94R200 switching from `newJsonModule` with the compatibility fixes to using `starlarkjson.Module` again