### PR TITLE
valueToStarlark support for enumKind

### DIFF
--- a/go/protomodule/protomodule_message.go
+++ b/go/protomodule/protomodule_message.go
@@ -40,6 +40,7 @@ func NewMessage(msg proto.Message) (*protoMessage, error) {
 	// Copy any existing set fields
 	var rangeErr error
 	msgReflect.Range(func(fd protoreflect.FieldDescriptor, v protoreflect.Value) bool {
+		// TODO: Range only iterates over populated fields so isFieldSet may be redundant
 		if isFieldSet(v, fd) {
 			starlarkValue, err := valueToStarlark(v, fd)
 			if err != nil {

--- a/go/protomodule/protomodule_message.go
+++ b/go/protomodule/protomodule_message.go
@@ -38,18 +38,22 @@ func NewMessage(msg proto.Message) (*protoMessage, error) {
 	fields := make(map[string]starlark.Value)
 
 	// Copy any existing set fields
+	var rangeErr error
 	msgReflect.Range(func(fd protoreflect.FieldDescriptor, v protoreflect.Value) bool {
 		if isFieldSet(v, fd) {
 			starlarkValue, err := valueToStarlark(v, fd)
 			if err != nil {
-				// Skip field rather than erroring to maintain skycfg.NewProtoMessage api
-				return true
+				rangeErr = err
+				return false
 			}
 			fields[string(fd.Name())] = starlarkValue
 
 		}
 		return true
 	})
+	if rangeErr != nil {
+		return nil, rangeErr
+	}
 
 	// Clone and reset the input msg to ensure no mutations
 	cloned := proto.Clone(msg)

--- a/go/protomodule/protomodule_message_test.go
+++ b/go/protomodule/protomodule_message_test.go
@@ -145,6 +145,16 @@ func TestMessageV2(t *testing.T) {
 	}
 	checkProtoEqual(t, wantMsg, gotMsg)
 
+	toStarlark, err := NewMessage(wantMsg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fromStarlark, ok := AsProtoMessage(toStarlark)
+	if !ok {
+		t.Fatal("AsProtoMessage returned false")
+	}
+	checkProtoEqual(t, wantMsg, fromStarlark)
+
 	wantAttrs := map[string]string{
 		"f_int32":         "1010",
 		"f_int64":         "1020",
@@ -252,6 +262,16 @@ func TestMessageV3(t *testing.T) {
 		FBytes:        []byte("also some string"),
 	}
 	checkProtoEqual(t, wantMsg, gotMsg)
+
+	toStarlark, err := NewMessage(wantMsg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fromStarlark, ok := AsProtoMessage(toStarlark)
+	if !ok {
+		t.Fatal("AsProtoMessage returned false")
+	}
+	checkProtoEqual(t, wantMsg, fromStarlark)
 
 	wantAttrs := map[string]string{
 		"f_int32":         "1010",

--- a/go/protomodule/type_conversions.go
+++ b/go/protomodule/type_conversions.go
@@ -216,6 +216,10 @@ func scalarValueToStarlark(val protoreflect.Value, fieldDesc protoreflect.FieldD
 	case protoreflect.BytesKind:
 		// Handle []byte ([]uint8) -> string special case.
 		return starlark.String(val.Bytes()), nil
+	case protoreflect.EnumKind:
+		enumNumber := val.Enum()
+		enumType := newEnumType(fieldDesc.Enum())
+		return enumType.ByNum(enumNumber)
 	case protoreflect.MessageKind:
 		if val.Interface() == nil {
 			return starlark.None, nil

--- a/go/protomodule/type_conversions.go
+++ b/go/protomodule/type_conversions.go
@@ -223,7 +223,7 @@ func scalarValueToStarlark(val protoreflect.Value, fieldDesc protoreflect.FieldD
 		return NewMessage(val.Message().Interface())
 	}
 
-	return starlark.None, fmt.Errorf("valueToStarlark: Value unuspported: %s\n", string(fieldDesc.FullName()))
+	return starlark.None, fmt.Errorf("valueToStarlark: Value unuspported: %T for %s (%s)\n", val.Interface(), string(fieldDesc.FullName()), fieldDesc.Kind().String())
 }
 
 // maybeConvertToWrapper checks if [val] is a primitive and [fieldDesc] is a corresponding

--- a/skycfg.go
+++ b/skycfg.go
@@ -86,9 +86,8 @@ func (r *localFileReader) ReadFile(ctx context.Context, path string) ([]byte, er
 
 // NewProtoMessage returns a Starlark value representing the given Protobuf
 // message. It can be returned back to a proto.Message() via AsProtoMessage().
-func NewProtoMessage(msg proto.Message) starlark.Value {
-	v, _ := protomodule.NewMessage(msg)
-	return v
+func NewProtoMessage(msg proto.Message) (starlark.Value, error) {
+	return protomodule.NewMessage(msg)
 }
 
 // AsProtoMessage returns a Protobuf message underlying the given Starlark


### PR DESCRIPTION
## Summary

`valueToStarlark` was missing support for enumKind so this PR:

- Return an error if a `NewMessage` fails to assign a value, updating the type signature in `skycfg.go`
- Adds a test for `msg == AsProtoMessage(NewMessage(msg))` which catches the issue
- Add missing support in `valueToStarlark`

## Tests
Added tests which should cover issues like this in the future
