### PR TITLE
Add flatten on eval

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -34,11 +34,10 @@ http_archive(
 
 http_archive(
     name = "rules_proto",
-    sha256 = "602e7161d9195e50246177e7c55b2f39950a9cf7366f74ed5f22fd45750cd208",
-    strip_prefix = "rules_proto-97d8af4dc474595af3900dd85cb3a29ad28cc313",
+    sha256 = "9850fcf6ad40fa348e6f13b2cfef4bb4639762f804794f2bf61d988f4ba0dae9",
+    strip_prefix = "rules_proto-4.0.0-3.19.2-2",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_proto/archive/97d8af4dc474595af3900dd85cb3a29ad28cc313.tar.gz",
-        "https://github.com/bazelbuild/rules_proto/archive/97d8af4dc474595af3900dd85cb3a29ad28cc313.tar.gz",
+        "https://github.com/bazelbuild/rules_proto/archive/refs/tags/4.0.0-3.19.2-2.tar.gz",
     ],
 )
 

--- a/skycfg.go
+++ b/skycfg.go
@@ -436,7 +436,6 @@ func (c *Config) Main(ctx context.Context, opts ...ExecOption) ([]proto.Message,
 		maybeMsg := mainList.Index(ii)
 		// Only flatten but not flatten deep. This will flatten out, in order, lists within main list and append the
 		// message into msgs
-
 		if maybeMsgList, ok := maybeMsg.(*starlark.List); parsedOpts.flattenLists && ok {
 			for iii := 0; iii < maybeMsgList.Len(); iii++ {
 				maybeNestedMsg := maybeMsgList.Index(iii)

--- a/skycfg.go
+++ b/skycfg.go
@@ -426,7 +426,8 @@ func (c *Config) Main(ctx context.Context, opts ...ExecOption) ([]proto.Message,
 	var msgs []proto.Message
 	for ii := 0; ii < mainList.Len(); ii++ {
 		maybeMsg := mainList.Index(ii)
-		// Only flatten but not flatten deep
+		// Only flatten but not flatten deep. This will flatten out, in order, lists within main list and append the
+		// message into msgs
 		maybeMsgList, ok := maybeMsg.(*starlark.List)
 		if ok {
 			for iii := 0; iii < maybeMsgList.Len(); iii++ {

--- a/skycfg_test.go
+++ b/skycfg_test.go
@@ -214,12 +214,13 @@ func (loader *testLoader) ReadFile(ctx context.Context, path string) ([]byte, er
 }
 
 type endToEndTestCase struct {
-	caseName   string
-	fileToLoad string
-	vars       starlark.StringDict
-	expLoadErr bool
-	expExecErr bool
-	expProtos  []proto.Message
+	caseName     string
+	fileToLoad   string
+	vars         starlark.StringDict
+	expLoadErr   bool
+	expExecErr   bool
+	expProtos    []proto.Message
+	flattenLists bool
 }
 
 type ExecSkycfg func(config *skycfg.Config, testCase endToEndTestCase) ([]proto.Message, error)
@@ -363,6 +364,7 @@ func TestSkycfgEndToEnd(t *testing.T) {
 					FString: proto.String("123456"),
 				},
 			},
+			flattenLists: true,
 		},
 		endToEndTestCase{
 			caseName:   "value err when attempting to autobox a too large integer into Int32Value",
@@ -387,7 +389,7 @@ func TestSkycfgEndToEnd(t *testing.T) {
 	}
 
 	fnExecSkycfg := ExecSkycfg(func(config *skycfg.Config, testCase endToEndTestCase) ([]proto.Message, error) {
-		return config.Main(context.Background(), skycfg.WithVars(testCase.vars))
+		return config.Main(context.Background(), skycfg.WithVars(testCase.vars), skycfg.WithFlattenLists())
 	})
 	runTestCases(t, testCases, fnExecSkycfg)
 }

--- a/skycfg_test.go
+++ b/skycfg_test.go
@@ -389,7 +389,12 @@ func TestSkycfgEndToEnd(t *testing.T) {
 	}
 
 	fnExecSkycfg := ExecSkycfg(func(config *skycfg.Config, testCase endToEndTestCase) ([]proto.Message, error) {
-		return config.Main(context.Background(), skycfg.WithVars(testCase.vars), skycfg.WithFlattenLists())
+		if testCase.flattenLists {
+			return config.Main(context.Background(), skycfg.WithVars(testCase.vars), skycfg.WithFlattenLists())
+		} else {
+			return config.Main(context.Background(), skycfg.WithVars(testCase.vars))
+		}
+
 	})
 	runTestCases(t, testCases, fnExecSkycfg)
 }

--- a/skycfg_test.go
+++ b/skycfg_test.go
@@ -177,6 +177,27 @@ def not_main(ctx):
 
 	return [msg]
 `,
+	"test13.sky": `
+test_proto = proto.package("skycfg.test_proto")
+
+# nested list
+def main(ctx):
+	msg = test_proto.MessageV2()
+	msg.f_int64 = 12345
+	msg.f_string = "12345"
+
+	msg2 = test_proto.MessageV2()
+	msg2.f_int64 = 123456
+	msg2.f_string = "123456"
+
+	msg3 = test_proto.MessageV2()
+	msg3.f_int64 = 1234567
+	msg3.f_string = "1234567"
+
+	innerlist = [msg, msg2]
+	outerlist = [msg3, innerlist]
+	return [outerlist]
+`,
 }
 
 // testLoader is a simple loader that loads files from the testFiles map.
@@ -345,6 +366,24 @@ func TestSkycfgEndToEnd(t *testing.T) {
 			caseName:   "value err when attempting to autobox a too large int into UInt32Value",
 			fileToLoad: "test11.sky",
 			expExecErr: true,
+		},
+		endToEndTestCase{
+			caseName:   "value err when attempting to autobox a too large int into UInt32Value",
+			fileToLoad: "test13.sky",
+			expProtos: []proto.Message{
+				&pb.MessageV2{
+					FInt64:  proto.Int64(12345),
+					FString: proto.String("12345"),
+				},
+				&pb.MessageV2{
+					FInt64:  proto.Int64(123456),
+					FString: proto.String("123456"),
+				},
+				&pb.MessageV2{
+					FInt64:  proto.Int64(1234567),
+					FString: proto.String("1234567"),
+				},
+			},
 		},
 	}
 

--- a/skycfg_test.go
+++ b/skycfg_test.go
@@ -195,8 +195,7 @@ def main(ctx):
 	msg3.f_string = "1234567"
 
 	innerlist = [msg, msg2]
-	outerlist = [msg3, innerlist]
-	return [outerlist]
+	return [msg3, innerlist]
 `,
 }
 
@@ -348,6 +347,24 @@ func TestSkycfgEndToEnd(t *testing.T) {
 			},
 		},
 		endToEndTestCase{
+			caseName:   "flatten nested list",
+			fileToLoad: "test13.sky",
+			expProtos: []proto.Message{
+				&pb.MessageV2{
+					FInt64:  proto.Int64(1234567),
+					FString: proto.String("1234567"),
+				},
+				&pb.MessageV2{
+					FInt64:  proto.Int64(12345),
+					FString: proto.String("12345"),
+				},
+				&pb.MessageV2{
+					FInt64:  proto.Int64(123456),
+					FString: proto.String("123456"),
+				},
+			},
+		},
+		endToEndTestCase{
 			caseName:   "value err when attempting to autobox a too large integer into Int32Value",
 			fileToLoad: "test8.sky",
 			expExecErr: true,
@@ -366,24 +383,6 @@ func TestSkycfgEndToEnd(t *testing.T) {
 			caseName:   "value err when attempting to autobox a too large int into UInt32Value",
 			fileToLoad: "test11.sky",
 			expExecErr: true,
-		},
-		endToEndTestCase{
-			caseName:   "value err when attempting to autobox a too large int into UInt32Value",
-			fileToLoad: "test13.sky",
-			expProtos: []proto.Message{
-				&pb.MessageV2{
-					FInt64:  proto.Int64(12345),
-					FString: proto.String("12345"),
-				},
-				&pb.MessageV2{
-					FInt64:  proto.Int64(123456),
-					FString: proto.String("123456"),
-				},
-				&pb.MessageV2{
-					FInt64:  proto.Int64(1234567),
-					FString: proto.String("1234567"),
-				},
-			},
 		},
 	}
 


### PR DESCRIPTION
Add ability to flatten nested list on evaluations with WithFlattenLists option.
Fix build due to deprecated zlib 1.2.11 
https://github.com/bazelbuild/rules_proto/pull/117
