### PR TITLE
Make prototext output deterministic

### DIFF
--- a/go/protomodule/protomodule_message.go
+++ b/go/protomodule/protomodule_message.go
@@ -98,7 +98,7 @@ var _ starlark.HasSetField = (*protoMessage)(nil)
 var _ starlark.Comparable = (*protoMessage)(nil)
 
 func (msg *protoMessage) String() string {
-	return fmt.Sprintf("<%s %s>", msg.Type(), (prototext.MarshalOptions{Multiline: false}).Format(msg.toProtoMessage()))
+	return fmt.Sprintf("<%s %s>", msg.Type(), (prototext.MarshalOptions{Multiline: false, Indent: ""}).Format(msg.toProtoMessage()))
 }
 func (msg *protoMessage) Type() string         { return string(msg.msgDesc.FullName()) }
 func (msg *protoMessage) Truth() starlark.Bool { return starlark.True }


### PR DESCRIPTION
Both the protojson and prototext renderings intentionally randomize the whitespace between attributes.  To make it possible to use printed representations of these proto messages in golden tests, we want to make it deterministic for normal daily use and accept that future library upgrades may need to also update the golden files.