### PR TITLE
Accommodate Starlark reserved keywords as Protobuf message field names

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -22,6 +22,7 @@ James Woglom <jwog@stripe.com>
 Josh Chorlton <choo@stripe.com>
 John Millikin <jmillikin@stripe.com>
 Julian Brown <jbrown@stripe.com>
+Kevin Lin <developer@kevinlin.info>
 Matt Moriarity <mmoriarity@stripe.com>
 Peter N <spacey-github.com@ssr.com>
 Ryan Brewster <RyanPBrewster@gmail.com> # Stripe, Inc.

--- a/go/protomodule/protomodule_message.go
+++ b/go/protomodule/protomodule_message.go
@@ -167,6 +167,8 @@ func (msg *protoMessage) MarshalJSON() ([]byte, error) {
 }
 
 func (msg *protoMessage) Attr(name string) (starlark.Value, error) {
+	name = attrNameToFieldName(name)
+
 	// If a value has already been set on msg, return it
 	if val, ok := msg.fields[name]; ok {
 		return val, nil
@@ -200,7 +202,11 @@ func (msg *protoMessage) Attr(name string) (starlark.Value, error) {
 }
 
 func (msg *protoMessage) AttrNames() []string {
-	return fieldNames(msg.msgDesc)
+	names := fieldNames(msg.msgDesc)
+	for i, field := range names {
+		names[i] = fieldNameToAttrName(field)
+	}
+	return names
 }
 
 func fieldNames(msgDesc protoreflect.MessageDescriptor) []string {
@@ -215,6 +221,8 @@ func fieldNames(msgDesc protoreflect.MessageDescriptor) []string {
 }
 
 func (msg *protoMessage) SetField(name string, val starlark.Value) error {
+	name = attrNameToFieldName(name)
+
 	fieldDesc := getFieldDescriptor(msg.msgDesc, name)
 	if fieldDesc == nil {
 		return fmt.Errorf("AttributeError: `%s' value has no field %q", msg.Type(), name)

--- a/go/protomodule/protomodule_message_test.go
+++ b/go/protomodule/protomodule_message_test.go
@@ -38,6 +38,7 @@ func TestMessageAttrNames(t *testing.T) {
 	}
 	got := val.(starlark.HasAttrs).AttrNames()
 	want := []string{
+		"assert_",
 		"f_int32",
 		"f_int64",
 		"f_uint32",
@@ -67,6 +68,9 @@ func TestMessageAttrNames(t *testing.T) {
 		"f_Uint64Value",
 		"r_StringValue",
 		"f_Any",
+		"pass_",
+		"return_",
+		"safe_",
 	}
 	sort.Strings(want)
 	if !reflect.DeepEqual(want, got) {
@@ -276,6 +280,12 @@ func TestMessageV3(t *testing.T) {
 				f_string = "string in f_Any",
 			)
 		),
+
+		# Reserved keywords suffixed with single underscore
+		pass_ = True,
+		return_ = True,
+		assert_ = True,
+		safe_ = True,
 	)`, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -328,6 +338,10 @@ func TestMessageV3(t *testing.T) {
 		F_Any: mustMarshalAny(t, &pb.MessageV3{
 			F_Any: mustMarshalAny(t, &pb.MessageV3{FString: "string in f_Any"}),
 		}),
+		Pass: true,
+		Return: true,
+		Assert: true,
+		Safe_: true,
 	}
 	checkProtoEqual(t, wantMsg, gotMsg)
 

--- a/go/protomodule/protomodule_message_type.go
+++ b/go/protomodule/protomodule_message_type.go
@@ -130,9 +130,10 @@ func (t *protoMessageType) CallInternal(
 	fields := t.descriptor.Fields()
 	for ii := 0; ii < fields.Len(); ii++ {
 		fieldName := string(fields.Get(ii).Name())
+		attrName := fieldNameToAttrName(fieldName)
 		v := new(starlark.Value)
-		parsedKwargs[fieldName] = v
-		parserPairs = append(parserPairs, fieldName+"?", v)
+		parsedKwargs[attrName] = v
+		parserPairs = append(parserPairs, attrName+"?", v)
 	}
 
 	if err := starlark.UnpackArgs(t.Name(), nil, kwargs, parserPairs...); err != nil {
@@ -144,10 +145,12 @@ func (t *protoMessageType) CallInternal(
 	if err != nil {
 		return nil, err
 	}
-	for fieldName, starlarkValue := range parsedKwargs {
+	for attrName, starlarkValue := range parsedKwargs {
 		if *starlarkValue == nil {
 			continue
 		}
+
+		fieldName := attrNameToFieldName(attrName)
 
 		if err := out.SetField(fieldName, *starlarkValue); err != nil {
 			return nil, err

--- a/go/protomodule/type_conversions.go
+++ b/go/protomodule/type_conversions.go
@@ -30,6 +30,46 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
+// reservedAttrNames is a static map of Starlark reserved keywords that cannot be used as attribute names.
+// Reference: https://github.com/bazelbuild/starlark/blob/c8d88c388698b0ee49bc74737f56236af64da1b5/spec.md#lexical-elements
+var reservedAttrNames = map[string]bool{
+	// Language keywords
+	"and":      true,
+	"break":    true,
+	"continue": true,
+	"def":      true,
+	"elif":     true,
+	"else":     true,
+	"for":      true,
+	"if":       true,
+	"in":       true,
+	"lambda":   true,
+	"load":     true,
+	"not":      true,
+	"or":       true,
+	"pass":     true,
+	"return":   true,
+	// Identifiers reserved for future use
+	"as":       true,
+	"assert":   true,
+	"async":    true,
+	"await":    true,
+	"class":    true,
+	"del":      true,
+	"except":   true,
+	"finally":  true,
+	"from":     true,
+	"global":   true,
+	"import":   true,
+	"is":       true,
+	"nonlocal": true,
+	"raise":    true,
+	"try":      true,
+	"while":    true,
+	"with":     true,
+	"yield":    true,
+}
+
 func valueFromStarlark(msg protoreflect.Message, fieldDesc protoreflect.FieldDescriptor, val starlark.Value) (protoreflect.Value, error) {
 	if fieldDesc.IsList() {
 		if list, ok := val.(*protoRepeated); ok {
@@ -392,4 +432,24 @@ func typeName(fieldDesc protoreflect.FieldDescriptor) string {
 	default:
 		return k.String()
 	}
+}
+
+func fieldNameToAttrName(name string) string {
+	if _, ok := reservedAttrNames[name]; !ok {
+		return name
+	}
+
+	return name + "_"
+}
+
+func attrNameToFieldName(name string) string {
+	if len(name) > 1 && name[len(name)-1] == '_' {
+		field := name[:len(name)-1]
+
+		if _, ok := reservedAttrNames[field]; ok {
+			return field
+		}
+	}
+
+	return name
 }

--- a/internal/testdata/test_proto/test_proto_v3.proto
+++ b/internal/testdata/test_proto/test_proto_v3.proto
@@ -77,7 +77,14 @@ message MessageV3 {
 
   google.protobuf.Any f_Any = 29;
 
-  // NEXT: 30
+  // Starlark reserved keywords
+  // Reference: https://github.com/bazelbuild/starlark/blob/c8d88c388698b0ee49bc74737f56236af64da1b5/spec.md#lexical-elements
+  bool pass = 30;
+  bool return = 31;
+  bool assert = 32;
+  bool safe_ = 33;
+
+  // NEXT: 34
 }
 
 enum ToplevelEnumV3 {


### PR DESCRIPTION
The Protobuf language permits identifiers that are reserved in Starlark, like `pass`. Consider, for example:

```protobuf
package foo;

message Foo {
    bool pass = 1;
}
```

There is currently no way to express this in Skycfg, since this is (correctly) flagged as a Starlark syntax error. For example:

```starlark
foopb = proto.package("foo");

def main(ctx):
    return [
        foopb.Foo(pass = True),
    ]
```

```
got pass, want primary expression
```

Language-specific Protobuf code generation plugins typically work around such collisions by suffixing identifiers with an underscore. This PR proposes using the same convention to enable use of such reserved keywords as attribute names when creating Protobuf messages in Skycfg.

This enables the above example to be expressed as:

```starlark
foopb = proto.package("foo");

def main(ctx):
    return [
        foopb.Foo(pass_ = True),
    ]
```

## Verification

I updated the unit tests.

```bash
$ bazelisk test //...
INFO: Invocation ID: 2aa156b0-26c2-4577-a35e-51ba751a7d18
Analyzing: 14 targets (15 packages loaded, 2996 targets configured)
INFO: Analyzed 14 targets (93 packages loaded, 7937 targets configured).
INFO: Found 8 targets and 6 test targets...
INFO: Elapsed time: 148.927s, Critical Path: 26.24s
INFO: 358 processes: 25 internal, 333 linux-sandbox.
INFO: Build completed successfully, 358 total actions
//:skycfg_test                                                           PASSED in 0.1s
//go/assertmodule:assertmodule_test                                      PASSED in 0.1s
//go/hashmodule:hashmodule_test                                          PASSED in 0.3s
//go/protomodule:protomodule_test                                        PASSED in 0.1s
//go/urlmodule:urlmodule_test                                            PASSED in 0.3s
//go/yamlmodule:yamlmodule_test                                          PASSED in 0.4s

Executed 6 out of 6 tests: 6 tests pass.
```