### PR TITLE
Support name and number accessors on enum values

### DIFF
--- a/go/protomodule/protomodule_enum.go
+++ b/go/protomodule/protomodule_enum.go
@@ -109,7 +109,7 @@ func (v *protoEnumValue) Attr(attrName string) (starlark.Value, error) {
 	switch attrName {
 	case "name":
 		return starlark.String(v.value.Name()), nil
-	case "number":
+	case "value":
 		return starlark.MakeInt64(int64(v.value.Number())), nil
 	default:
 		return nil, fmt.Errorf("unknown attribute %s on %s", attrName, v.String())
@@ -117,7 +117,7 @@ func (v *protoEnumValue) Attr(attrName string) (starlark.Value, error) {
 }
 
 func (v *protoEnumValue) AttrNames() []string {
-	return []string{"name", "number"}
+	return []string{"name", "value"}
 }
 
 func (v *protoEnumValue) enumNumber() protoreflect.EnumNumber {

--- a/go/protomodule/protomodule_enum.go
+++ b/go/protomodule/protomodule_enum.go
@@ -92,6 +92,7 @@ type protoEnumValue struct {
 }
 
 var _ starlark.Comparable = (*protoEnumValue)(nil)
+var _ starlark.HasAttrs = (*protoEnumValue)(nil)
 var _ starlark.Value = (*protoEnumValue)(nil)
 
 func (v *protoEnumValue) String() string {
@@ -102,6 +103,21 @@ func (v *protoEnumValue) Freeze()              {}
 func (v *protoEnumValue) Truth() starlark.Bool { return starlark.True }
 func (v *protoEnumValue) Hash() (uint32, error) {
 	return starlark.MakeInt64(int64(v.value.Number())).Hash()
+}
+
+func (v *protoEnumValue) Attr(attrName string) (starlark.Value, error) {
+	switch attrName {
+	case "name":
+		return starlark.String(v.value.Name()), nil
+	case "number":
+		return starlark.MakeInt64(int64(v.value.Number())), nil
+	default:
+		return nil, fmt.Errorf("unknown attribute %s on %s", attrName, v.String())
+	}
+}
+
+func (v *protoEnumValue) AttrNames() []string {
+	return []string{"name", "number"}
 }
 
 func (v *protoEnumValue) enumNumber() protoreflect.EnumNumber {

--- a/go/protomodule/protomodule_test.go
+++ b/go/protomodule/protomodule_test.go
@@ -133,14 +133,14 @@ func TestEnumType(t *testing.T) {
 		},
 		{
 			src:  `dir(pb.ToplevelEnumV2.TOPLEVEL_ENUM_V2_B)`,
-			want: `["name", "number"]`,
+			want: `["name", "value"]`,
 		},
 		{
 			src:  `pb.ToplevelEnumV2.TOPLEVEL_ENUM_V2_B.name`,
 			want: `"TOPLEVEL_ENUM_V2_B"`,
 		},
 		{
-			src:  `pb.ToplevelEnumV2.TOPLEVEL_ENUM_V2_B.number`,
+			src:  `pb.ToplevelEnumV2.TOPLEVEL_ENUM_V2_B.value`,
 			want: `1`,
 		},
 		{
@@ -165,14 +165,14 @@ func TestEnumType(t *testing.T) {
 		},
 		{
 			src:  `dir(pb.MessageV2.NestedEnum.NESTED_ENUM_B)`,
-			want: `["name", "number"]`,
+			want: `["name", "value"]`,
 		},
 		{
 			src:  `pb.MessageV2.NestedEnum.NESTED_ENUM_B.name`,
 			want: `"NESTED_ENUM_B"`,
 		},
 		{
-			src:  `pb.MessageV2.NestedEnum.NESTED_ENUM_B.number`,
+			src:  `pb.MessageV2.NestedEnum.NESTED_ENUM_B.value`,
 			want: `1`,
 		},
 		{

--- a/go/protomodule/protomodule_test.go
+++ b/go/protomodule/protomodule_test.go
@@ -128,6 +128,26 @@ func TestEnumType(t *testing.T) {
 			want: `["TOPLEVEL_ENUM_V2_A", "TOPLEVEL_ENUM_V2_B"]`,
 		},
 		{
+			src:  `pb.ToplevelEnumV2.TOPLEVEL_ENUM_V2_B`,
+			want: `<skycfg.test_proto.ToplevelEnumV2 TOPLEVEL_ENUM_V2_B=1>`,
+		},
+		{
+			src:  `dir(pb.ToplevelEnumV2.TOPLEVEL_ENUM_V2_B)`,
+			want: `["name", "number"]`,
+		},
+		{
+			src:  `pb.ToplevelEnumV2.TOPLEVEL_ENUM_V2_B.name`,
+			want: `"TOPLEVEL_ENUM_V2_B"`,
+		},
+		{
+			src:  `pb.ToplevelEnumV2.TOPLEVEL_ENUM_V2_B.number`,
+			want: `1`,
+		},
+		{
+			src:     `pb.ToplevelEnumV2.TOPLEVEL_ENUM_V2_B.invalid`,
+			wantErr: errors.New(`unknown attribute invalid on <skycfg.test_proto.ToplevelEnumV2 TOPLEVEL_ENUM_V2_B=1>`),
+		},
+		{
 			src:  `pb.MessageV2.NestedEnum`,
 			want: `<proto.EnumType "skycfg.test_proto.MessageV2.NestedEnum">`,
 		},
@@ -138,6 +158,26 @@ func TestEnumType(t *testing.T) {
 		{
 			src:     `pb.ToplevelEnumV2.NoExist`,
 			wantErr: errors.New(`proto.EnumType has no .NoExist field or method`),
+		},
+		{
+			src:  `pb.MessageV2.NestedEnum.NESTED_ENUM_B`,
+			want: `<skycfg.test_proto.MessageV2.NestedEnum NESTED_ENUM_B=1>`,
+		},
+		{
+			src:  `dir(pb.MessageV2.NestedEnum.NESTED_ENUM_B)`,
+			want: `["name", "number"]`,
+		},
+		{
+			src:  `pb.MessageV2.NestedEnum.NESTED_ENUM_B.name`,
+			want: `"NESTED_ENUM_B"`,
+		},
+		{
+			src:  `pb.MessageV2.NestedEnum.NESTED_ENUM_B.number`,
+			want: `1`,
+		},
+		{
+			src:     `pb.MessageV2.NestedEnum.NESTED_ENUM_B.invalid`,
+			wantErr: errors.New(`unknown attribute invalid on <skycfg.test_proto.MessageV2.NestedEnum NESTED_ENUM_B=1>`),
 		},
 	}, withGlobals(globals))
 }


### PR DESCRIPTION
Currently, Protobuf enum values have a `String()` method defined, which provides a human-readable representation of the value with `str(...)` in Starlark, including the value's name and number (index). However, there is no interface to retrieve *only* the name and number of an enum value for use in Skycfg programs.

This PR proposes augmenting the enum value type with two attributes, `name` and `value`, which expose the enum value descriptor's name and number, respectively.

This enables a definition like:

```protobuf
enum Foo {
    HELLO = 0;
    WORLD = 1;
}
```

to be used in Skycfg like:

```starlark
pb.Foo.HELLO.name  # "HELLO" (string)
pb.Foo.HELLO.value  # 0 (int)
```

I added unit tests to cover the new logic (as well as some additional tests to cover existing logic for the `str(...)` representation of values).

```bash
$ bazelisk test --cache_test_results=no //...
INFO: Invocation ID: 0c384b38-64b0-461b-985b-ed281b040175
INFO: Analyzed 14 targets (0 packages loaded, 1 target configured).
INFO: Found 8 targets and 6 test targets...
INFO: Elapsed time: 0.102s, Critical Path: 0.03s
INFO: 7 processes: 1 internal, 6 linux-sandbox.
INFO: Build completed successfully, 7 total actions
//:skycfg_test                                                           PASSED in 0.0s
//go/assertmodule:assertmodule_test                                      PASSED in 0.0s
//go/hashmodule:hashmodule_test                                          PASSED in 0.0s
//go/protomodule:protomodule_test                                        PASSED in 0.0s
//go/urlmodule:urlmodule_test                                            PASSED in 0.0s
//go/yamlmodule:yamlmodule_test                                          PASSED in 0.0s

Executed 6 out of 6 tests: 6 tests pass.
There were tests whose specified size is too big. Use the --test_verbose_timeout_warnings command line option to see which ones these are.
```