### PR TITLE
Support custom error message in assertion module

### DIFF
--- a/go/assertmodule/assert.go
+++ b/go/assertmodule/assert.go
@@ -119,12 +119,14 @@ func (t *TestContext) AttrNames() []string {
 // CallInternal is the implementation for assert(...)
 func (t *TestContext) CallInternal(thread *starlark.Thread, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 	var val bool
-	if err := starlark.UnpackPositionalArgs("assert", args, kwargs, 1, &val); err != nil {
+	var msg starlark.String
+	if err := starlark.UnpackArgs("assert", args, kwargs, "val", &val, "msg?", &msg); err != nil {
 		return nil, err
 	}
 
 	if !val {
 		err := assertionError{
+			msg:       string(msg),
 			callStack: thread.CallStack(),
 		}
 		t.Failures = append(t.Failures, err)

--- a/go/assertmodule/assert_test.go
+++ b/go/assertmodule/assert_test.go
@@ -102,7 +102,7 @@ func TestUnaryAsserts(t *testing.T) {
 
 		if testCase.msg != "" {
 			cmd = fmt.Sprintf(
-				`t.assert(%s, "%s")`,
+				`t.assert(%s, %q)`,
 				testCase.val,
 				testCase.msg,
 			)

--- a/go/assertmodule/assert_test.go
+++ b/go/assertmodule/assert_test.go
@@ -55,6 +55,7 @@ type assertBinaryTestCase struct {
 type assertUnaryTestCase struct {
 	assertTestCaseImpl
 	val string
+	msg string
 }
 
 func TestUnaryAsserts(t *testing.T) {
@@ -68,11 +69,28 @@ func TestUnaryAsserts(t *testing.T) {
 		},
 		assertUnaryTestCase{
 			assertTestCaseImpl: assertTestCaseImpl{
+				expFailure: false,
+				expError:   false,
+			},
+			val: `1 == 1`,
+			msg: "unary assertion error message",
+		},
+		assertUnaryTestCase{
+			assertTestCaseImpl: assertTestCaseImpl{
 				expFailure:    true,
 				expFailureMsg: "assertion failed",
 				expError:      false,
 			},
 			val: `2 == 1`,
+		},
+		assertUnaryTestCase{
+			assertTestCaseImpl: assertTestCaseImpl{
+				expFailure:    true,
+				expFailureMsg: "assertion failed: unary assertion error message",
+				expError:      false,
+			},
+			val: `2 == 1`,
+			msg: "unary assertion error message",
 		},
 	}
 
@@ -81,6 +99,14 @@ func TestUnaryAsserts(t *testing.T) {
 			`t.assert(%s)`,
 			testCase.val,
 		)
+
+		if testCase.msg != "" {
+			cmd = fmt.Sprintf(
+				`t.assert(%s, "%s")`,
+				testCase.val,
+				testCase.msg,
+			)
+		}
 
 		evalAndReportResults(t, cmd, testCase)
 	}


### PR DESCRIPTION
This PR proposes the addition of an optional secondary argument to `ctx.assert(...)` which enables unit test callsites to specify a custom assertion failure error message.

This looks like, for example:

```starlark
def test_foo(ctx):
    ctx.assert(False)

def test_foo_message(ctx):
    ctx.assert(False, "foo error message")
```

Executing these tests results in:

```
[foo.sky:2:15] assertion failed
...
```

```
[foo.sky:4:15] assertion failed: foo error message
...
```

I added corresponding unit test coverage.

```bash
$ bazelisk test --cache_test_results=no //go/...
INFO: Invocation ID: bc5157d2-13f6-4d45-84b3-42aae65fc926
INFO: Analyzed 10 targets (0 packages loaded, 137 targets configured).
INFO: Found 5 targets and 5 test targets...
INFO: Elapsed time: 2.453s, Critical Path: 0.51s
INFO: 6 processes: 1 internal, 5 processwrapper-sandbox.
INFO: Build completed successfully, 6 total actions
//go/assertmodule:assertmodule_test                                      PASSED in 0.3s
//go/hashmodule:hashmodule_test                                          PASSED in 0.4s
//go/protomodule:protomodule_test                                        PASSED in 0.5s
//go/urlmodule:urlmodule_test                                            PASSED in 0.4s
//go/yamlmodule:yamlmodule_test                                          PASSED in 0.3s
```