### PR TITLE
Add murmur3 to hash module

### DIFF
--- a/build/go_dependencies.bzl
+++ b/build/go_dependencies.bzl
@@ -26,6 +26,12 @@ def go_dependencies():
         version = "v1.0.0",
     )
     go_repository(
+        name = "com_github_spaolacci_murmur3",
+        importpath = "github.com/spaolacci/murmur3",
+        sum = "h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=",
+        version = "v1.1.0",
+    )
+    go_repository(
         name = "in_gopkg_check_v1",
         importpath = "gopkg.in/check.v1",
         sum = "h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=",

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/stripe/skycfg
 go 1.16
 
 require (
+	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	go.starlark.net v0.0.0-20201204201740-42d4f566359b
 	google.golang.org/protobuf v1.25.0
 	gopkg.in/yaml.v2 v2.2.1

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.0 h1:/QaMHBdZ26BB3SSst0Iwl10Epc+xhTquomWX0oZEB6w=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
+github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 go.starlark.net v0.0.0-20201204201740-42d4f566359b h1:yHUzJ1WfcdR1oOafytJ6K1/ntYwnEIXICNVzHb+FzbA=
 go.starlark.net v0.0.0-20201204201740-42d4f566359b/go.mod h1:5YFcFnRptTN+41758c2bMPiqpGg4zBfYji1IQz8wNFk=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/go/hashmodule/BUILD
+++ b/go/hashmodule/BUILD
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/stripe/skycfg/go/hashmodule",
     visibility = ["//visibility:public"],
     deps = [
+        "@com_github_spaolacci_murmur3//:go_default_library",
         "@net_starlark_go//starlark",
         "@net_starlark_go//starlarkstruct",
     ],

--- a/go/hashmodule/hashmodule.go
+++ b/go/hashmodule/hashmodule.go
@@ -24,17 +24,20 @@ import (
 	"fmt"
 	"hash"
 
+	"github.com/spaolacci/murmur3"
+
 	"go.starlark.net/starlark"
 	"go.starlark.net/starlarkstruct"
 )
 
 // NewModule returns a Starlark module of common hash functions.
 //
-//  hash = module(
-//    md5,
-//    sha1,
-//    sha256,
-//  )
+// hash = module(
+//	md5,
+//	sha1,
+//	sha256,
+//	murmur3,
+// )
 //
 // See `docs/modules.asciidoc` for details on the API of each function.
 func NewModule() *starlarkstruct.Module {
@@ -44,11 +47,25 @@ func NewModule() *starlarkstruct.Module {
 			"md5":    starlark.NewBuiltin("hash.md5", fnHash(md5.New)),
 			"sha1":   starlark.NewBuiltin("hash.sha1", fnHash(sha1.New)),
 			"sha256": starlark.NewBuiltin("hash.sha256", fnHash(sha256.New)),
+			"murmur3": starlark.NewBuiltin("hash.murmur3", fnHash64(murmur3.New64)),
 		},
 	}
 }
 
 func fnHash(hash func() hash.Hash) func(*starlark.Thread, *starlark.Builtin, starlark.Tuple, []starlark.Tuple) (starlark.Value, error) {
+	return func(t *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+		var s starlark.String
+		if err := starlark.UnpackPositionalArgs(fn.Name(), args, kwargs, 1, &s); err != nil {
+			return nil, err
+		}
+
+		h := hash()
+		h.Write([]byte(string(s)))
+		return starlark.String(fmt.Sprintf("%x", h.Sum(nil))), nil
+	}
+}
+
+func fnHash64(hash func() hash.Hash64) func(*starlark.Thread, *starlark.Builtin, starlark.Tuple, []starlark.Tuple) (starlark.Value, error) {
 	return func(t *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 		var s starlark.String
 		if err := starlark.UnpackPositionalArgs(fn.Name(), args, kwargs, 1, &s); err != nil {

--- a/go/hashmodule/hashmodule_test.go
+++ b/go/hashmodule/hashmodule_test.go
@@ -51,6 +51,11 @@ func TestHashes(t *testing.T) {
 			hashFunc:  "sha256",
 			expOutput: "a9c78816353b119a0ba2a1281675b147fd47abee11a8d41d5abb739dce8273b7",
 		},
+		hashTestCase{
+			input:     "test murmur3 string",
+			hashFunc:  "murmur3",
+			expOutput: "91dd87efc613eb2c",
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
As per the description, we wanted to use murmur3, hence we'd like to add it to the hash module. We are experimenting with it internally at Stripe for some CI tooling, given its known better performance for fair distribution of a small set of inputs.