### PR TITLE
Make protobuf map --> starlark.Dict ordering deterministic

### DIFF
--- a/go/protomodule/protomodule_test.go
+++ b/go/protomodule/protomodule_test.go
@@ -370,6 +370,25 @@ def fun():
 	})
 }
 
+func Test_MapEntryIterationOrder(t *testing.T) {
+	// When the host provides a Go map value, there's no natural well-defined iteration order.
+	// Go is intentionally non-deterministic.
+	// skycfg is intentionally constructing a deterministically ordered starlark map.
+	// This test will become flaky if we ever stop imposing deterministic ordering.
+	msg, err := NewMessage(&pb.MessageV3{
+		MapString: map[string]string{"foo": "1", "bar": "2"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	runSkycfgTests(t, []skycfgTest{
+		{
+			src:  `";".join(my_msg.map_string.keys())`,
+			want: `"bar;foo"`,
+		},
+	}, withGlobals(starlark.StringDict{"my_msg": msg}))
+}
+
 // Skycfg has had inconsistent copy on assignment behavior
 // Test that Skycfg does not copy lists/maps on assignment, matching Starlark/Python's behavior
 func TestNoCopyOnAssignment(t *testing.T) {

--- a/go/protomodule/type_conversions.go
+++ b/go/protomodule/type_conversions.go
@@ -21,8 +21,10 @@ package protomodule
 import (
 	"fmt"
 	"math"
+	"sort"
 
 	"go.starlark.net/starlark"
+	"go.starlark.net/syntax"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
@@ -147,44 +149,15 @@ func scalarValueFromStarlark(fieldDesc protoreflect.FieldDescriptor, val starlar
 func valueToStarlark(val protoreflect.Value, fieldDesc protoreflect.FieldDescriptor) (starlark.Value, error) {
 	if fieldDesc.IsList() {
 		if listVal, ok := val.Interface().(protoreflect.List); ok {
-			out := newProtoRepeated(fieldDesc)
-			for i := 0; i < listVal.Len(); i++ {
-				starlarkValue, err := scalarValueToStarlark(listVal.Get(i), fieldDesc)
-				if err != nil {
-					return starlark.None, err
-				}
-				out.Append(starlarkValue)
-			}
-			return out, nil
+			return listValueToStarlark(listVal, fieldDesc)
 		} else if val.Interface() == nil {
 			return newProtoRepeated(fieldDesc), nil
 		}
 		return starlark.None, fmt.Errorf("TypeError: cannot convert %T into list", val.Interface())
-	} else if fieldDesc.IsMap() {
+	}
+	if fieldDesc.IsMap() {
 		if mapVal, ok := val.Interface().(protoreflect.Map); ok {
-			out := newProtoMap(fieldDesc.MapKey(), fieldDesc.MapValue())
-			var rangeErr error
-			mapVal.Range(func(k protoreflect.MapKey, v protoreflect.Value) bool {
-				starlarkKey, err := scalarValueToStarlark(protoreflect.Value(k), fieldDesc.MapKey())
-				if err != nil {
-					rangeErr = err
-					return false
-				}
-
-				starlarkValue, err := scalarValueToStarlark(v, fieldDesc.MapValue())
-				if err != nil {
-					rangeErr = err
-					return false
-				}
-
-				out.SetKey(starlarkKey, starlarkValue)
-				return true
-			})
-			if rangeErr != nil {
-				return starlark.None, rangeErr
-			}
-
-			return out, nil
+			return mapValueToStarlark(mapVal, fieldDesc.MapKey(), fieldDesc.MapValue())
 		} else if val.Interface() == nil {
 			return newProtoMap(fieldDesc.MapKey(), fieldDesc.MapValue()), nil
 		}
@@ -192,6 +165,73 @@ func valueToStarlark(val protoreflect.Value, fieldDesc protoreflect.FieldDescrip
 	}
 
 	return scalarValueToStarlark(val, fieldDesc)
+}
+
+// listValueToStarlark wraps a protobuf list as a starlark.Value.
+func listValueToStarlark(listVal protoreflect.List, fieldDesc protoreflect.FieldDescriptor) (starlark.Value, error) {
+	out := newProtoRepeated(fieldDesc)
+	for i := 0; i < listVal.Len(); i++ {
+		starlarkValue, err := scalarValueToStarlark(listVal.Get(i), fieldDesc)
+		if err != nil {
+			return starlark.None, err
+		}
+		out.Append(starlarkValue)
+	}
+	return out, nil
+}
+
+// mapValueToStarlark wraps a protobuf map as a starlark.Value.
+func mapValueToStarlark(mapVal protoreflect.Map, keyType, valueType protoreflect.FieldDescriptor) (starlark.Value, error) {
+	// protoreflect.Map.Range iterates through entries in an
+	// unspecified, nondeterministic order. This is good for efficiency
+	// but bad for deterministic execution. We're going to try and
+	// ensure that the resulting starlark.Value (which is a *protoMap
+	// backed by a *starlark.Dict) is constructed in a deterministic
+	// order so that skycfg code can iterate through it in a
+	// deterministic order. starlark.Dict uses a linked hashtable
+	// implementation that iterates through items in insertion order.
+	type kv struct {
+		key   starlark.Value
+		value starlark.Value
+	}
+	var kvs []kv
+	var rangeErr error
+	mapVal.Range(func(k protoreflect.MapKey, v protoreflect.Value) bool {
+		starlarkKey, err := scalarValueToStarlark(protoreflect.Value(k), keyType)
+		if err != nil {
+			rangeErr = err
+			return false
+		}
+
+		starlarkValue, err := scalarValueToStarlark(v, valueType)
+		if err != nil {
+			rangeErr = err
+			return false
+		}
+
+		kvs = append(kvs, kv{key: starlarkKey, value: starlarkValue})
+		return true
+	})
+	if rangeErr != nil {
+		return starlark.None, rangeErr
+	}
+
+	// Attempt to sort the map by key to ensure that the result is "as
+	// deterministic as possible".  Not all starlark values are
+	// comparable. If that is the case, the ordering will be arbitrary.
+	// I believe that *protoMap only supports scalar keys, in which case
+	// the error condition should never be hit.
+	sort.Slice(kvs, func(i, j int) bool {
+		less, _ := starlark.Compare(syntax.LT, kvs[i].key, kvs[j].key)
+		return less
+	})
+	out := newProtoMap(keyType, valueType)
+	for _, item := range kvs {
+		if err := out.SetKey(item.key, item.value); err != nil {
+			return starlark.None, err
+		}
+	}
+	return out, nil
 }
 
 func scalarValueToStarlark(val protoreflect.Value, fieldDesc protoreflect.FieldDescriptor) (starlark.Value, error) {


### PR DESCRIPTION
If I have a protobuf map in the host environment (say as a context variable), iterating through it is non-deterministic. That results in some pretty gnarly workarounds in the starlark code itself.

This PR performs some best-effort deterministic at the starlark conversion stage. It ensures that protobuf map items are inserts into the starlark dictionary in naturally sorted order (using starlark's own internal partial ordering).

Sorting is really awkward in starlark itself, so this type of convenience is extremely helpful