### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        os: ["ubuntu-20.04"]
+        os: ["ubuntu-24.04"]
         go:
           - series: "1.13"
             version: "1.13.15"
@@ -18,10 +18,10 @@ jobs:
             version: "1.15.5"
 
     steps:
-      - uses: "actions/checkout@v2"
+      - uses: "actions/checkout@v4"
         with:
           path: "src"
-      - uses: "actions/cache@v2"
+      - uses: "actions/cache@v4"
         with:
           path: "cache"
           key: "os=${{ matrix.os }};go=${{ matrix.go.version }};v=1"


### PR DESCRIPTION
Upgrade to newer versions of the steps we use & bump OS. Upgrading Go versions will require upgrading rules_go which in turn will require upgrading Bazel.

I did not want to go down that path yet.