### PR TITLE
Update AUTHORS and CONTRIBUTORS

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -15,3 +15,4 @@ Alex Gaynor <alex.gaynor@gmail.com>
 Charles Xu <charlesxu1995@gmail.com>
 Chun-Hung Hsiao <chhsiao@apache.org>
 Peter N <spacey-github.com@ssr.com>
+Taras Tsugrii <taras.tsugriy@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -7,5 +7,11 @@
 # Names of people must include a contact email, in the format:
 #     Name <email address>
 
-Stripe, Inc.
 GM Cruise LLC
+Mux, Inc.
+Stripe, Inc.
+
+Alex Gaynor <alex.gaynor@gmail.com>
+Charles Xu <charlesxu1995@gmail.com>
+Chun-Hung Hsiao <chhsiao@apache.org>
+Peter N <spacey-github.com@ssr.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -6,14 +6,14 @@
 #     Name <email address>
 
 Aditya Anchuri <aadi@stripe.com>
-Alex Gaynor <alex.gaynor@gmail.com> # TODO
+Alex Gaynor <alex.gaynor@gmail.com>
 Alexander Pakulov <apakulov@stripe.com>
 Andrew Bloom <abloom@stripe.com>
 Benjamin Yolken <yolken@stripe.com>
 Can Yucel <can.yucel@gmail.com> # GM Cruise LLC
-Charles Xu <charlesxu1995@gmail.com> # TODO
-Chun-Hung Hsiao <chhsiao@apache.org> # TODO
-Dmitry Ilyevsky <dilyevsky@mux.com> # TODO
+Charles Xu <charlesxu1995@gmail.com>
+Chun-Hung Hsiao <chhsiao@apache.org>
+Dmitry Ilyevsky <dilyevsky@mux.com>
 Dmitry Ilyevsky <ilyevsky@gmail.com> # GM Cruise LLC
 Garvin Pang <garvinp@stripe.com>
 Henry Coelho <henryc@stripe.com>
@@ -23,11 +23,11 @@ Josh Chorlton <choo@stripe.com>
 John Millikin <jmillikin@stripe.com>
 Julian Brown <jbrown@stripe.com>
 Matt Moriarity <mmoriarity@stripe.com>
-Peter N <spacey-github.com@ssr.com> # TODO
+Peter N <spacey-github.com@ssr.com>
 Ryan Brewster <RyanPBrewster@gmail.com> # Stripe, Inc.
 Seena Burns <seena@stripe.com>
 Sushain Cherivirala <sushain@skc.name> # Stripe, Inc.
-Taras Tsugrii <taras.tsugriy@gmail.com> # TODO
+Taras Tsugrii <taras.tsugriy@gmail.com>
 Timothy Gu <timothyg@stripe.com>
 Yuhuan Qiu <yq@stripe.com>
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -13,7 +13,7 @@ Benjamin Yolken <yolken@stripe.com>
 Can Yucel <can.yucel@gmail.com> # GM Cruise LLC
 Charles Xu <charlesxu1995@gmail.com> # TODO
 Chun-Hung Hsiao <chhsiao@apache.org> # TODO
-dilyevsky <dilyevsky@mux.com> # TODO
+Dmitry Ilyevsky <dilyevsky@mux.com> # TODO
 Dmitry Ilyevsky <ilyevsky@gmail.com> # GM Cruise LLC
 Garvin Pang <garvinp@stripe.com>
 Henry Coelho <henryc@stripe.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -5,13 +5,30 @@
 # Names should be added to this file as:
 #     Name <email address>
 
+Aditya Anchuri <aadi@stripe.com>
+Alex Gaynor <alex.gaynor@gmail.com> # TODO
 Alexander Pakulov <apakulov@stripe.com>
 Andrew Bloom <abloom@stripe.com>
 Benjamin Yolken <yolken@stripe.com>
+Can Yucel <can.yucel@gmail.com> # GM Cruise LLC
+Charles Xu <charlesxu1995@gmail.com> # TODO
+Chun-Hung Hsiao <chhsiao@apache.org> # TODO
+dilyevsky <dilyevsky@mux.com> # TODO
 Dmitry Ilyevsky <ilyevsky@gmail.com> # GM Cruise LLC
+Garvin Pang <garvinp@stripe.com>
+Henry Coelho <henryc@stripe.com>
 Isaac Diamond <idiamond@stripe.com>
+James Woglom <jwog@stripe.com>
+Josh Chorlton <choo@stripe.com>
 John Millikin <jmillikin@stripe.com>
+Julian Brown <jbrown@stripe.com>
 Matt Moriarity <mmoriarity@stripe.com>
+Peter N <spacey-github.com@ssr.com> # TODO
+Ryan Brewster <RyanPBrewster@gmail.com> # Stripe, Inc.
 Seena Burns <seena@stripe.com>
+Sushain Cherivirala <sushain@skc.name> # Stripe, Inc.
+Taras Tsugrii <taras.tsugriy@gmail.com> # TODO
+Timothy Gu <timothyg@stripe.com>
+Yuhuan Qiu <yq@stripe.com>
 
 # Please alphabetize new entries.


### PR DESCRIPTION
* Add emails of more folks who contributed to the repo to CONTRIBUTORS

* Add additional copyright attribution to AUTHORS.

    * The following contributors made PRs to this repo before this repo required a CLA:
      ```
      Alex Gaynor <alex.gaynor@gmail.com>
      Charles Xu <charlesxu1995@gmail.com>
      Chun-Hung Hsiao <chhsiao@apache.org>
      Peter N <spacey-github.com@ssr.com>
      ```
      Presumably they contributed in their individual capacity only.

    * `Dmitry Ilyevsky <dilyevsky@mux.com>` contributed with their `mux.com` email address, so presumably Mux, Inc. holds the copyright.

    * `Can Yucel <can.yucel@gmail.com>` contributed commit 59f0bc70f5a900d52a7754d2d0b0ab1d018a4876, which has a `Signed-off-by: Jon Yucel <jon.yucel@getcruise.com>`, so presumably GM Cruise LLC is the copyright holder.