### PR TITLE
Additionally support custom error message in binary-argument assertions

### DIFF
--- a/go/assertmodule/assert.go
+++ b/go/assertmodule/assert.go
@@ -141,7 +141,8 @@ func (t *TestContext) AssertBinaryImpl(op syntax.Token) func(thread *starlark.Th
 	return func(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
 		var val1 starlark.Value
 		var val2 starlark.Value
-		if err := starlark.UnpackPositionalArgs(fn.Name(), args, kwargs, 2, &val1, &val2); err != nil {
+		var msg starlark.String
+		if err := starlark.UnpackArgs(fn.Name(), args, kwargs, "val1", &val1, "val2", &val2, "msg?", &msg); err != nil {
 			return nil, err
 		}
 
@@ -155,6 +156,7 @@ func (t *TestContext) AssertBinaryImpl(op syntax.Token) func(thread *starlark.Th
 				op:        &op,
 				val1:      val1,
 				val2:      val2,
+				msg:       string(msg),
 				callStack: thread.CallStack(),
 			}
 			t.Failures = append(t.Failures, err)

--- a/go/assertmodule/assert_test.go
+++ b/go/assertmodule/assert_test.go
@@ -103,7 +103,7 @@ func TestUnaryAsserts(t *testing.T) {
 
 		if testCase.msg != "" {
 			cmd = fmt.Sprintf(
-				`t.assert(%s, "%s")`,
+				`t.assert(%s, %q)`,
 				testCase.val,
 				testCase.msg,
 			)
@@ -302,7 +302,7 @@ func TestBinaryAsserts(t *testing.T) {
 
 		if testCase.msg != "" {
 			cmd = fmt.Sprintf(
-				`t.assert.%s(%s, %s, "%s")`,
+				`t.assert.%s(%s, %s, %q)`,
 				tokenToString[testCase.op],
 				testCase.val1Str,
 				testCase.val2Str,

--- a/go/assertmodule/assert_test.go
+++ b/go/assertmodule/assert_test.go
@@ -50,6 +50,7 @@ type assertBinaryTestCase struct {
 	op      syntax.Token
 	val1Str string
 	val2Str string
+	msg     string
 }
 
 type assertUnaryTestCase struct {
@@ -102,7 +103,7 @@ func TestUnaryAsserts(t *testing.T) {
 
 		if testCase.msg != "" {
 			cmd = fmt.Sprintf(
-				`t.assert(%s, %q)`,
+				`t.assert(%s, "%s")`,
 				testCase.val,
 				testCase.msg,
 			)
@@ -126,10 +127,31 @@ func TestBinaryAsserts(t *testing.T) {
 		assertBinaryTestCase{
 			op:      syntax.EQL,
 			val1Str: `"hello"`,
+			val2Str: `"hello"`,
+			msg:     "binary assertion error message",
+			assertTestCaseImpl: assertTestCaseImpl{
+				expFailure: false,
+				expError:   false,
+			},
+		},
+		assertBinaryTestCase{
+			op:      syntax.EQL,
+			val1Str: `"hello"`,
 			val2Str: `"nothello"`,
 			assertTestCaseImpl: assertTestCaseImpl{
 				expFailure:    true,
 				expFailureMsg: `"hello" (type: string) == "nothello" (type: string)`,
+				expError:      false,
+			},
+		},
+		assertBinaryTestCase{
+			op:      syntax.EQL,
+			val1Str: `"hello"`,
+			val2Str: `"nothello"`,
+			msg:     "binary assertion error message",
+			assertTestCaseImpl: assertTestCaseImpl{
+				expFailure:    true,
+				expFailureMsg: `binary assertion error message`,
 				expError:      false,
 			},
 		},
@@ -277,6 +299,17 @@ func TestBinaryAsserts(t *testing.T) {
 			testCase.val1Str,
 			testCase.val2Str,
 		)
+
+		if testCase.msg != "" {
+			cmd = fmt.Sprintf(
+				`t.assert.%s(%s, %s, "%s")`,
+				tokenToString[testCase.op],
+				testCase.val1Str,
+				testCase.val2Str,
+				testCase.msg,
+			)
+		}
+
 		evalAndReportResults(t, cmd, testCase)
 	}
 }


### PR DESCRIPTION
This is an extension to #121, which allows specification of a custom assertion error message. #121 supports specifying a message for unary assertions:

```starlark
t.assert(true, "foo")
```

This PR additionally extends the same functionality to support binary assertions:

```starlark
t.assert.equal(1, 1, "foo")
```

Minimal end-to-end example:

```starlark
# foo.sky

def test_foo(ctx):
    ctx.assert.equal(0, 0, "assert1")
    ctx.assert.equal(0, 1, "assert2")
```

```go
// main.go

package main

import (
	"context"
	"fmt"

	"github.com/stripe/skycfg"
)

func main() {
	cfg, err := skycfg.Load(context.Background(), "foo.sky")
	if err != nil {
		panic(err)
	}

	for _, t := range cfg.Tests() {
		result, err := t.Run(context.Background())
		if err != nil {
			panic(err)
		}

		fmt.Println(result.Failure)
	}
}

```

Example output:

```
[foo.sky:3:21] assertion failed: assert2
Traceback (most recent call last):
  foo.sky:3:21: in test_foo
```