### PR TITLE
Some more tooling upgrades

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,6 +12,7 @@ jobs:
     strategy:
       matrix:
         go:
+          # Keep minimum version up to date with go.mod
           - series: "1.22"
             version: "1.22.12"
           - series: "1.23"

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /bazel-*
+*.pb.go

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -31,9 +31,9 @@ go_test(
     name = "skycfg_test",
     size = "small",
     srcs = ["skycfg_test.go"],
-    embed = [":skycfg"],
     deps = [
-        "//internal/testdata/test_proto:test_proto_go_proto",
+        ":skycfg",
+        "//internal/test_proto:test_proto_go_proto",
         "@net_starlark_go//starlark",
         "@org_golang_google_protobuf//proto",
         "@org_golang_google_protobuf//types/known/wrapperspb",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -41,3 +41,13 @@ go_test(
 )
 
 gazelle(name = "gazelle")
+
+gazelle(
+    name = "gazelle-update-repos",
+    args = [
+        "-from_file=go.mod",
+        "-to_macro=build/go_dependencies.bzl%go_dependencies",
+        "-prune",
+    ],
+    command = "update-repos",
+)

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Bazel is the officially supported build system for skycfg. To regenerate BUILD f
 
 ```bash
 $ bazel run //:gazelle
-$ bazel run //:gazelle -- update-repos # if there are go.mod/go.sum changes
+$ bazel run //:gazelle-update-repos # if there are go.mod changes
 ```
 
 However, the `go` toolchain is unofficially supported as well. To get started:

--- a/README.md
+++ b/README.md
@@ -167,6 +167,21 @@ $ ./test-skycfg
 
 We welcome contributions from the community. For small simple changes, go ahead and [open a pull request](https://github.com/stripe/skycfg/compare). Larger changes should start out in the issue tracker, so we can make sure they fit into the roadmap. Changes to the Starlark language itself (such as new primitive types or syntax) should be applied to https://github.com/google/starlark-go.
 
+Bazel is the officially supported build system for skycfg. To regenerate BUILD files, run:
+
+```bash
+$ bazel run //:gazelle
+$ bazel run //:gazelle -- update-repos # if there are go.mod/go.sum changes
+```
+
+However, the `go` toolchain is unofficially supported as well. To get started:
+
+```bash
+$ go install google.golang.org/protobuf/cmd/protoc-gen-go
+$ go generate ./...
+$ go test ./...
+```
+
 ## Stability
 
 Skycfg depends on internal details of the go-protobuf generated code, and as such may need to be updated to work with future versions of go-protobuf. We will release Skycfg v1.0 after all dependencies on go-protobuf implementation details have been fixed, which will be after the "api-v2" branch lands in a stable release of go-protobuf.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -32,10 +32,10 @@ go_register_toolchains(go_version = GO_VERSION)
 
 http_archive(
     name = "bazel_gazelle",
-    sha256 = "75df288c4b31c81eb50f51e2e14f4763cb7548daae126817247064637fd9ea62",
+    sha256 = "aefbf2fc7c7616c9ed73aa3d51c77100724d5b3ce66cfa16406e8c13e87c8b52",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.36.0/bazel-gazelle-v0.36.0.tar.gz",
-        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.36.0/bazel-gazelle-v0.36.0.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.41.0/bazel-gazelle-v0.41.0.tar.gz",
+        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.41.0/bazel-gazelle-v0.41.0.tar.gz",
     ],
 )
 

--- a/build/go_dependencies.bzl
+++ b/build/go_dependencies.bzl
@@ -32,18 +32,6 @@ def go_dependencies():
         version = "v0.5.5",
     )
     go_repository(
-        name = "com_github_kisielk_errcheck",
-        importpath = "github.com/kisielk/errcheck",
-        sum = "h1:reN85Pxc5larApoH1keMBiu2GWtPqXQ1nc9gx+jOU+E=",
-        version = "v1.2.0",
-    )
-    go_repository(
-        name = "com_github_kisielk_gotool",
-        importpath = "github.com/kisielk/gotool",
-        sum = "h1:AV2c/EiW3KqPNT9ZKl07ehoAGi4C5/01Cfbblndcapg=",
-        version = "v1.0.0",
-    )
-    go_repository(
         name = "com_github_spaolacci_murmur3",
         importpath = "github.com/spaolacci/murmur3",
         sum = "h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=",
@@ -78,13 +66,6 @@ def go_dependencies():
         importpath = "golang.org/x/sys",
         sum = "h1:B6caxRw+hozq68X2MY7jEpZh/cr4/aHLv9xU8Kkadrw=",
         version = "v0.0.0-20200803210538-64077c9b5642",
-    )
-
-    go_repository(
-        name = "org_golang_x_tools",
-        importpath = "golang.org/x/tools",
-        sum = "h1:NIou6eNFigscvKJmsbyez16S2cIS6idossORlFtSt2E=",
-        version = "v0.0.0-20181030221726-6c7e314b6563",
     )
     go_repository(
         name = "org_golang_x_xerrors",

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/stripe/skycfg
 
-go 1.24
+go 1.22
 
 require (
 	github.com/spaolacci/murmur3 v1.1.0
@@ -8,3 +8,5 @@ require (
 	google.golang.org/protobuf v1.33.0
 	gopkg.in/yaml.v2 v2.2.1
 )
+
+require golang.org/x/sys v0.0.0-20200803210538-64077c9b5642 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,6 @@
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
-github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
@@ -12,7 +11,6 @@ golang.org/x/sys v0.0.0-20200803210538-64077c9b5642 h1:B6caxRw+hozq68X2MY7jEpZh/
 golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
 google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/go/assertmodule/BUILD
+++ b/go/assertmodule/BUILD
@@ -18,9 +18,7 @@ go_library(
 go_test(
     name = "assertmodule_test",
     size = "small",
-    srcs = [
-        "assert_test.go",
-    ],
+    srcs = ["assert_test.go"],
     embed = [":assertmodule"],
     deps = [
         "@net_starlark_go//starlark",

--- a/go/hashmodule/BUILD
+++ b/go/hashmodule/BUILD
@@ -6,7 +6,7 @@ go_library(
     importpath = "github.com/stripe/skycfg/go/hashmodule",
     visibility = ["//visibility:public"],
     deps = [
-        "@com_github_spaolacci_murmur3//:go_default_library",
+        "@com_github_spaolacci_murmur3//:murmur3",
         "@net_starlark_go//starlark",
         "@net_starlark_go//starlarkstruct",
     ],

--- a/go/protomodule/BUILD
+++ b/go/protomodule/BUILD
@@ -33,19 +33,21 @@ go_library(
 go_test(
     name = "protomodule_test",
     srcs = [
-        "protomodule_test.go",
         "protomodule_message_test.go",
+        "protomodule_test.go",
     ],
     embed = [":protomodule"],
     deps = [
-        "//:skycfg",
-        "//internal/testdata/test_proto:test_proto_go_proto",
+        "//internal/test_proto:test_proto_go_proto",
         "@net_starlark_go//resolve",
         "@net_starlark_go//starlark",
         "@net_starlark_go//starlarkstruct",
         "@net_starlark_go//syntax",
+        "@org_golang_google_protobuf//encoding/prototext",
+        "@org_golang_google_protobuf//proto",
+        "@org_golang_google_protobuf//reflect/protoreflect",
         "@org_golang_google_protobuf//reflect/protoregistry",
-        "@org_golang_google_protobuf//types/descriptorpb",
         "@org_golang_google_protobuf//types/known/anypb",
+        "@org_golang_google_protobuf//types/known/wrapperspb",
     ],
 )

--- a/go/protomodule/protomodule_message_test.go
+++ b/go/protomodule/protomodule_message_test.go
@@ -28,7 +28,7 @@ import (
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
-	pb "github.com/stripe/skycfg/internal/testdata/test_proto"
+	pb "github.com/stripe/skycfg/internal/test_proto"
 )
 
 func TestMessageAttrNames(t *testing.T) {

--- a/go/protomodule/protomodule_test.go
+++ b/go/protomodule/protomodule_test.go
@@ -29,9 +29,8 @@ import (
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/reflect/protoregistry"
 	"google.golang.org/protobuf/types/known/anypb"
-	any "google.golang.org/protobuf/types/known/anypb"
 
-	pb "github.com/stripe/skycfg/internal/testdata/test_proto"
+	pb "github.com/stripe/skycfg/internal/test_proto"
 )
 
 func init() {
@@ -658,7 +657,7 @@ func TestProtoToAnyV3(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	myAny := mustProtoMessage(t, val).(*any.Any)
+	myAny := mustProtoMessage(t, val).(*anypb.Any)
 
 	want := "type.googleapis.com/skycfg.test_proto.MessageV3"
 	if want != myAny.GetTypeUrl() {
@@ -751,7 +750,7 @@ func runSkycfgTests(t *testing.T, tests []skycfgTest, opts ...globalTestOption) 
 
 			if test.wantType != "" {
 				if val.Type() != test.wantType {
-					t.Fatalf("Expected type\nwanted: %t\ngot   : %t", test.wantType, val.Type())
+					t.Fatalf("Expected type\nwanted: %s\ngot   : %s", test.wantType, val.Type())
 				}
 			}
 		})

--- a/internal/test_proto/BUILD
+++ b/internal/test_proto/BUILD
@@ -1,5 +1,5 @@
-load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 # gazelle:exclude package.go
 
@@ -12,18 +12,18 @@ proto_library(
     import_prefix = "github.com/stripe/skycfg",  # keep
     visibility = ["//:__subpackages__"],
     deps = [
-        "@com_google_protobuf//:wrappers_proto",
         "@com_google_protobuf//:any_proto",
+        "@com_google_protobuf//:wrappers_proto",
     ],
 )
 
 go_proto_library(
     name = "test_proto_go_proto",
-    importpath = "github.com/stripe/skycfg/internal/testdata/test_proto",
+    importpath = "github.com/stripe/skycfg/internal/test_proto",
     proto = ":test_proto",
     visibility = ["//:__subpackages__"],
     deps = [
-        "@io_bazel_rules_go//proto/wkt:wrappers_go_proto",  # keep
         "@io_bazel_rules_go//proto/wkt:any_go_proto",  # keep
+        "@io_bazel_rules_go//proto/wkt:wrappers_go_proto",  # keep
     ],
 )

--- a/internal/test_proto/package.go
+++ b/internal/test_proto/package.go
@@ -1,0 +1,3 @@
+package test_proto
+
+//go:generate protoc --go_out=paths=source_relative:. test_proto_v2.proto test_proto_v3.proto

--- a/internal/test_proto/test_proto_v2.proto
+++ b/internal/test_proto/test_proto_v2.proto
@@ -16,7 +16,7 @@
 
 syntax = "proto2";
 
-option go_package = "github.com/stripe/skycfg/internal/testdata/test_proto";
+option go_package = "github.com/stripe/skycfg/internal/test_proto";
 package skycfg.test_proto;
 
 import "google/protobuf/wrappers.proto";

--- a/internal/test_proto/test_proto_v3.proto
+++ b/internal/test_proto/test_proto_v3.proto
@@ -16,7 +16,7 @@
 
 syntax = "proto3";
 
-option go_package = "github.com/stripe/skycfg/internal/testdata/test_proto";
+option go_package = "github.com/stripe/skycfg/internal/test_proto";
 package skycfg.test_proto;
 
 import "google/protobuf/wrappers.proto";

--- a/internal/testdata/test_proto/package.go
+++ b/internal/testdata/test_proto/package.go
@@ -1,1 +1,0 @@
-package test_proto

--- a/skycfg_test.go
+++ b/skycfg_test.go
@@ -25,10 +25,10 @@ import (
 
 	"go.starlark.net/starlark"
 	"google.golang.org/protobuf/proto"
-	wrappers "google.golang.org/protobuf/types/known/wrapperspb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/stripe/skycfg"
-	pb "github.com/stripe/skycfg/internal/testdata/test_proto"
+	pb "github.com/stripe/skycfg/internal/test_proto"
 )
 
 var testFiles = map[string]string{
@@ -465,18 +465,18 @@ func TestSkycfgEndToEnd(t *testing.T) {
 			expExecErr: false,
 			expProtos: []proto.Message{
 				&pb.MessageV3{
-					F_BoolValue:   &wrappers.BoolValue{Value: true},
-					F_StringValue: &wrappers.StringValue{Value: "something"},
-					F_DoubleValue: &wrappers.DoubleValue{Value: 3110.4120},
-					F_Int32Value:  &wrappers.Int32Value{Value: 110},
-					F_Int64Value:  &wrappers.Int64Value{Value: 2148483647},
-					F_BytesValue:  &wrappers.BytesValue{Value: []byte("foo/bar/baz")},
-					F_Uint32Value: &wrappers.UInt32Value{Value: 4294967295},
-					F_Uint64Value: &wrappers.UInt64Value{Value: 8294967295},
-					R_StringValue: []*wrappers.StringValue{
-						&wrappers.StringValue{Value: "s1"},
-						&wrappers.StringValue{Value: "s2"},
-						&wrappers.StringValue{Value: "s3"},
+					F_BoolValue:   &wrapperspb.BoolValue{Value: true},
+					F_StringValue: &wrapperspb.StringValue{Value: "something"},
+					F_DoubleValue: &wrapperspb.DoubleValue{Value: 3110.4120},
+					F_Int32Value:  &wrapperspb.Int32Value{Value: 110},
+					F_Int64Value:  &wrapperspb.Int64Value{Value: 2148483647},
+					F_BytesValue:  &wrapperspb.BytesValue{Value: []byte("foo/bar/baz")},
+					F_Uint32Value: &wrapperspb.UInt32Value{Value: 4294967295},
+					F_Uint64Value: &wrapperspb.UInt64Value{Value: 8294967295},
+					R_StringValue: []*wrapperspb.StringValue{
+						&wrapperspb.StringValue{Value: "s1"},
+						&wrapperspb.StringValue{Value: "s2"},
+						&wrapperspb.StringValue{Value: "s3"},
 					},
 				},
 			},
@@ -863,7 +863,7 @@ func TestSkycfgTesting(t *testing.T) {
 
 	tests := config.Tests()
 	if len(tests) != len(cases) {
-		t.Error("Expected %d tests but found %d", len(cases), len(tests))
+		t.Errorf("Expected %d tests but found %d", len(cases), len(tests))
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
* Downgrade minimum supported Go version in go.mod to 1.22. We test 1.22–1.24 in CI. This fixes #131.
* Upgrade bazel-gazelle.
* Add basic docs on how to contribute to this repo.
* Add basic support for native `go` toolchain.