### PR TITLE
Add FSFileReader

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -9,7 +9,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "skycfg",
-    srcs = ["skycfg.go"],
+    srcs = [
+        "reader.go",
+        "skycfg.go",
+    ],
     importpath = "github.com/stripe/skycfg",
     visibility = ["//visibility:public"],
     deps = [

--- a/reader.go
+++ b/reader.go
@@ -1,0 +1,92 @@
+// Copyright 2025 The Skycfg Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package skycfg
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+// A FileReader controls how load() calls resolve and read other modules.
+type FileReader interface {
+	// Resolve parses the "name" part of load("name", "symbol") to a path. This
+	// is not required to correspond to a true path on the filesystem, but should
+	// be "absolute" within the semantics of this FileReader.
+	//
+	// fromPath will be empty when loading the root module passed to Load().
+	Resolve(ctx context.Context, name, fromPath string) (path string, err error)
+
+	// ReadFile reads the content of the file at the given path, which was
+	// returned from Resolve().
+	ReadFile(ctx context.Context, path string) ([]byte, error)
+}
+
+type localFileReader struct {
+	root string
+}
+
+// LocalFileReader returns a [FileReader] that resolves and loads files from
+// within a given filesystem directory.
+// LocalFileReader expects paths in load() to always use '/' as the separator,
+// regardless of the operating system's native path separator.
+func LocalFileReader(root string) FileReader {
+	if root == "" {
+		panic("LocalFileReader: empty root path")
+	}
+	return &localFileReader{root}
+}
+
+func (r *localFileReader) Resolve(ctx context.Context, name, fromPath string) (string, error) {
+	if fromPath == "" {
+		return name, nil
+	}
+	if filepath.Separator != '/' && strings.ContainsRune(name, filepath.Separator) {
+		return "", fmt.Errorf("load(%q): invalid character in module name", name)
+	}
+	resolved := filepath.Join(r.root, filepath.FromSlash(path.Clean("/"+name)))
+	return resolved, nil
+}
+
+func (r *localFileReader) ReadFile(ctx context.Context, path string) ([]byte, error) {
+	return os.ReadFile(path)
+}
+
+type fsFileReader struct {
+	fsys fs.FS
+}
+
+// FSFileReader returns a [FileReader] that loads files from the given [fs.FS].
+// Path resolution on a FSFileReader is just [path.Clean].
+func FSFileReader(fsys fs.FS) FileReader {
+	if fsys == nil {
+		panic("FSFileReader: nil fsys")
+	}
+	return &fsFileReader{fsys: fsys}
+}
+
+func (r *fsFileReader) Resolve(ctx context.Context, name, fromPath string) (string, error) {
+	return path.Clean(name), nil
+}
+
+func (r *fsFileReader) ReadFile(ctx context.Context, path string) ([]byte, error) {
+	return fs.ReadFile(r.fsys, path)
+}

--- a/skycfg.go
+++ b/skycfg.go
@@ -22,7 +22,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"io/fs"
 	"os"
 	"path"
 	"path/filepath"
@@ -69,8 +69,10 @@ type localFileReader struct {
 	root string
 }
 
-// LocalFileReader returns a FileReader that resolves and loads files from
+// LocalFileReader returns a [FileReader] that resolves and loads files from
 // within a given filesystem directory.
+// LocalFileReader expects paths in load() to always use '/' as the separator,
+// regardless of the operating system's native path separator.
 func LocalFileReader(root string) FileReader {
 	if root == "" {
 		panic("LocalFileReader: empty root path")
@@ -90,7 +92,28 @@ func (r *localFileReader) Resolve(ctx context.Context, name, fromPath string) (s
 }
 
 func (r *localFileReader) ReadFile(ctx context.Context, path string) ([]byte, error) {
-	return ioutil.ReadFile(path)
+	return os.ReadFile(path)
+}
+
+type fsFileReader struct {
+	fsys fs.FS
+}
+
+// FSFileReader returns a [FileReader] that loads files from the given [fs.FS].
+// Path resolution on a FSFileReader is just [path.Clean].
+func FSFileReader(fsys fs.FS) FileReader {
+	if fsys == nil {
+		panic("FSFileReader: nil fsys")
+	}
+	return &fsFileReader{fsys: fsys}
+}
+
+func (r *fsFileReader) Resolve(ctx context.Context, name, fromPath string) (string, error) {
+	return path.Clean(name), nil
+}
+
+func (r *fsFileReader) ReadFile(ctx context.Context, path string) ([]byte, error) {
+	return fs.ReadFile(r.fsys, path)
 }
 
 // NewProtoMessage returns a Starlark value representing the given Protobuf

--- a/skycfg.go
+++ b/skycfg.go
@@ -22,9 +22,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/fs"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -50,71 +48,6 @@ const (
 	contextKey   = "context"   // has type context.Context
 	logOutputKey = "logoutput" // has type io.Writer
 )
-
-// A FileReader controls how load() calls resolve and read other modules.
-type FileReader interface {
-	// Resolve parses the "name" part of load("name", "symbol") to a path. This
-	// is not required to correspond to a true path on the filesystem, but should
-	// be "absolute" within the semantics of this FileReader.
-	//
-	// fromPath will be empty when loading the root module passed to Load().
-	Resolve(ctx context.Context, name, fromPath string) (path string, err error)
-
-	// ReadFile reads the content of the file at the given path, which was
-	// returned from Resolve().
-	ReadFile(ctx context.Context, path string) ([]byte, error)
-}
-
-type localFileReader struct {
-	root string
-}
-
-// LocalFileReader returns a [FileReader] that resolves and loads files from
-// within a given filesystem directory.
-// LocalFileReader expects paths in load() to always use '/' as the separator,
-// regardless of the operating system's native path separator.
-func LocalFileReader(root string) FileReader {
-	if root == "" {
-		panic("LocalFileReader: empty root path")
-	}
-	return &localFileReader{root}
-}
-
-func (r *localFileReader) Resolve(ctx context.Context, name, fromPath string) (string, error) {
-	if fromPath == "" {
-		return name, nil
-	}
-	if filepath.Separator != '/' && strings.ContainsRune(name, filepath.Separator) {
-		return "", fmt.Errorf("load(%q): invalid character in module name", name)
-	}
-	resolved := filepath.Join(r.root, filepath.FromSlash(path.Clean("/"+name)))
-	return resolved, nil
-}
-
-func (r *localFileReader) ReadFile(ctx context.Context, path string) ([]byte, error) {
-	return os.ReadFile(path)
-}
-
-type fsFileReader struct {
-	fsys fs.FS
-}
-
-// FSFileReader returns a [FileReader] that loads files from the given [fs.FS].
-// Path resolution on a FSFileReader is just [path.Clean].
-func FSFileReader(fsys fs.FS) FileReader {
-	if fsys == nil {
-		panic("FSFileReader: nil fsys")
-	}
-	return &fsFileReader{fsys: fsys}
-}
-
-func (r *fsFileReader) Resolve(ctx context.Context, name, fromPath string) (string, error) {
-	return path.Clean(name), nil
-}
-
-func (r *fsFileReader) ReadFile(ctx context.Context, path string) ([]byte, error) {
-	return fs.ReadFile(r.fsys, path)
-}
 
 // NewProtoMessage returns a Starlark value representing the given Protobuf
 // message. It can be returned back to a proto.Message() via AsProtoMessage().

--- a/skycfg_test.go
+++ b/skycfg_test.go
@@ -23,6 +23,7 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"testing/fstest"
 
 	"go.starlark.net/starlark"
 	"go.starlark.net/syntax"
@@ -60,6 +61,16 @@ def main(ctx):
 	msg.r_string.append(ctx.vars["var_key"])
 	helper3(ctx)
 
+	return [msg]
+`,
+	"test1_weird_paths.sky": `
+load(".////test2.sky", "helper2")
+
+test_proto = proto.package("skycfg.test_proto")
+
+def main(ctx):
+	msg = test_proto.MessageV2()
+	msg.f_string = json.encode(helper2(ctx))
 	return [msg]
 `,
 	"test2.sky": `
@@ -364,6 +375,16 @@ def main(ctx):
 `,
 }
 
+func testFSLoader() skycfg.FileReader {
+	mapFS := fstest.MapFS{}
+	for path, content := range testFiles {
+		mapFS[path] = &fstest.MapFile{
+			Data: []byte(content),
+		}
+	}
+	return skycfg.FSFileReader(mapFS)
+}
+
 // testLoader is a simple loader that loads files from the testFiles map.
 type testLoader struct {
 	HiddenFiles map[string]bool // pretend files in this map don't exist
@@ -385,6 +406,7 @@ func (loader *testLoader) ReadFile(ctx context.Context, path string) ([]byte, er
 type endToEndTestCase struct {
 	caseName    string
 	fileToLoad  string
+	useFSLoader bool // use testFSLoader instead of testLoader
 	vars        starlark.StringDict
 	expLoadErr  bool
 	expExecErr  bool
@@ -396,17 +418,25 @@ type endToEndTestCase struct {
 type ExecSkycfg func(config *skycfg.Config, testCase endToEndTestCase) ([]proto.Message, error)
 
 func runTestCases(t *testing.T, testCases []endToEndTestCase, execSkycfg ExecSkycfg) {
-	loader := &testLoader{}
+	testLoader := &testLoader{}
+	fsLoader := testFSLoader()
 	var cache skycfg.LoadCache
 	ctx := context.Background()
 
 	for _, testCase := range testCases {
-		loadOpts := []skycfg.LoadOption{skycfg.WithFileReader(loader)}
+		loader := skycfg.FileReader(testLoader)
+		if testCase.useFSLoader {
+			loader = fsLoader
+		}
 
+		loadOpts := []skycfg.LoadOption{skycfg.WithFileReader(loader)}
 		if testCase.loadOptions != nil {
 			loadOpts = append(loadOpts, testCase.loadOptions...)
-		} else {
-			// Only exercise load cache if the test case didn't provide special loadOptions.
+		}
+
+		// Exercise load cache if the test case didn't provide special loadOptions
+		// and we're using standard file loader.
+		if testCase.loadOptions == nil && !testCase.useFSLoader {
 			loadOpts = append(loadOpts, skycfg.WithLoadCache(&cache))
 		}
 
@@ -486,6 +516,29 @@ func TestSkycfgEndToEnd(t *testing.T) {
 						`{"key1":"value1","key2":"key3=value3","key4":{"key5":"value5","var_key":"var_value"}}`,
 					),
 					RString: []string{"var_value"},
+				},
+			},
+		},
+		endToEndTestCase{
+			caseName:   "weird path fails",
+			fileToLoad: "test1_weird_paths.sky",
+			vars: starlark.StringDict{
+				"var_key": starlark.String("var_value"),
+			},
+			expLoadErr: true,
+		},
+		endToEndTestCase{
+			caseName:    "weird path works with FSFileReader",
+			fileToLoad:  "test1_weird_paths.sky",
+			useFSLoader: true,
+			vars: starlark.StringDict{
+				"var_key": starlark.String("var_value"),
+			},
+			expProtos: []proto.Message{
+				&pb.MessageV2{
+					FString: proto.String(
+						`{"key1":"value1","key2":"key3=value3","key4":{"key5":"value5","var_key":"var_value"}}`,
+					),
 				},
 			},
 		},


### PR DESCRIPTION
Add an implementation of [FileReader](https://pkg.go.dev/github.com/stripe/skycfg#FileReader) that reads from a [io/fs.FS](https://pkg.go.dev/io/fs#FS). This is a version of what we've been using internally.