### PR TITLE
protomodule: performance optimizations

### DIFF
--- a/go/protomodule/bench_test.go
+++ b/go/protomodule/bench_test.go
@@ -1,0 +1,255 @@
+package protomodule
+
+import (
+	"testing"
+
+	pb "github.com/stripe/skycfg/internal/test_proto"
+	"go.starlark.net/starlark"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+var (
+	benchmarkNewMessage_empty_sink *protoMessage
+	benchmarkNewMessage_empty_err  error
+)
+
+func BenchmarkNewMessage_empty(b *testing.B) {
+	wantMsg := &pb.MessageV2{}
+	benchmarkNewMessage_empty_sink, benchmarkNewMessage_empty_err = NewMessage(wantMsg)
+	b.ResetTimer()
+	for range b.N {
+		benchmarkNewMessage_empty_sink, benchmarkNewMessage_empty_err = NewMessage(wantMsg)
+	}
+}
+
+var (
+	benchmarkNewMessage_full_sink *protoMessage
+	benchmarkNewMessage_full_err  error
+)
+
+func BenchmarkNewMessage_full(b *testing.B) {
+	wantMsg := &pb.MessageV2{
+		FInt32:   proto.Int32(1010),
+		FInt64:   proto.Int64(1020),
+		FUint32:  proto.Uint32(1030),
+		FUint64:  proto.Uint64(1040),
+		FFloat32: proto.Float32(10.50),
+		FFloat64: proto.Float64(10.60),
+		FString:  proto.String("some string"),
+		FBool:    proto.Bool(true),
+		FSubmsg: &pb.MessageV2{
+			FString: proto.String("string in submsg"),
+		},
+		RString: []string{"r_string1", "r_string2"},
+		RSubmsg: []*pb.MessageV2{{
+			FString: proto.String("string in r_submsg"),
+		}},
+		MapString: map[string]string{
+			"map_string key": "map_string val",
+		},
+		MapSubmsg: map[string]*pb.MessageV2{
+			"map_submsg key": {
+				FString: proto.String("map_submsg val"),
+			},
+		},
+		FNestedSubmsg: &pb.MessageV2_NestedMessage{
+			FString: proto.String("nested_submsg val"),
+		},
+		FToplevelEnum: pb.ToplevelEnumV2_TOPLEVEL_ENUM_V2_B.Enum(),
+		FNestedEnum:   pb.MessageV2_NESTED_ENUM_B.Enum(),
+		FOneof:        &pb.MessageV2_FOneofB{FOneofB: "string in oneof"},
+		FBytes:        []byte("also some string"),
+		F_BoolValue:   &wrapperspb.BoolValue{Value: true},
+		F_StringValue: &wrapperspb.StringValue{Value: "something"},
+		F_DoubleValue: &wrapperspb.DoubleValue{Value: 3110.4120},
+		F_Int32Value:  &wrapperspb.Int32Value{Value: 110},
+		F_Int64Value:  &wrapperspb.Int64Value{Value: 2148483647},
+		F_BytesValue:  &wrapperspb.BytesValue{Value: []byte("foo/bar/baz")},
+		F_Uint32Value: &wrapperspb.UInt32Value{Value: 4294967295},
+		F_Uint64Value: &wrapperspb.UInt64Value{Value: 8294967295},
+		R_StringValue: []*wrapperspb.StringValue{
+			{Value: "s1"},
+			{Value: "s2"},
+			{Value: "s3"},
+		},
+	}
+	benchmarkNewMessage_full_sink, benchmarkNewMessage_full_err = NewMessage(wantMsg)
+
+	b.ResetTimer()
+	for range b.N {
+		benchmarkNewMessage_full_sink, benchmarkNewMessage_full_err = NewMessage(wantMsg)
+	}
+}
+
+var (
+	benchmarkMessage_Attr_unpopulatedScalar_sink starlark.Value
+	benchmarkMessage_Attr_unpopulatedScalar_err  error
+)
+
+func BenchmarkMessage_Attr_unpopulatedScalar(b *testing.B) {
+	msg, err := NewMessage(&pb.MessageV3{})
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+	for range b.N {
+		benchmarkMessage_Attr_unpopulatedScalar_sink, benchmarkMessage_Attr_unpopulatedScalar_err = msg.Attr("f_int32")
+	}
+}
+
+var (
+	benchmarkMessage_Attr_populatedScalar_sink starlark.Value
+	benchmarkMessage_Attr_populatedScalar_err  error
+)
+
+func BenchmarkMessage_Attr_populatedScalar(b *testing.B) {
+	msg, err := NewMessage(&pb.MessageV3{
+		FInt32: 42,
+	})
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+	for range b.N {
+		benchmarkMessage_Attr_populatedScalar_sink, benchmarkMessage_Attr_populatedScalar_err = msg.Attr("f_int32")
+	}
+}
+
+var (
+	benchmarkMessage_Attr_unpopulatedList_sink starlark.Value
+	benchmarkMessage_Attr_unpopulatedList_err  error
+)
+
+func BenchmarkMessage_Attr_unpopulatedList(b *testing.B) {
+	msg, err := NewMessage(&pb.MessageV3{})
+	if err != nil {
+		b.Fatal(err)
+	}
+	msg.Freeze()
+	b.ResetTimer()
+	for range b.N {
+		benchmarkMessage_Attr_unpopulatedList_sink, benchmarkMessage_Attr_unpopulatedList_err = msg.Attr("r_string")
+	}
+}
+
+var (
+	benchmarkMessage_Attr_populatedList_sink starlark.Value
+	benchmarkMessage_Attr_populatedList_err  error
+)
+
+func BenchmarkMessage_Attr_populatedList(b *testing.B) {
+	msg, err := NewMessage(&pb.MessageV3{
+		RString: []string{"a", "b", "c"},
+	})
+	if err != nil {
+		b.Fatal(err)
+	}
+	msg.Freeze()
+	b.ResetTimer()
+	for range b.N {
+		benchmarkMessage_Attr_populatedList_sink, benchmarkMessage_Attr_populatedList_err = msg.Attr("r_string")
+	}
+}
+
+var (
+	benchmarkMessage_Attr_unpopulatedLastItem_sink starlark.Value
+	benchmarkMessage_Attr_unpopulatedLastItem_err  error
+)
+
+func BenchmarkMessage_Attr_unpopulatedLastItem(b *testing.B) {
+	msg, err := NewMessage(&pb.MessageV3{})
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+
+	for range b.N {
+		benchmarkMessage_Attr_unpopulatedLastItem_sink, benchmarkMessage_Attr_unpopulatedLastItem_err = msg.Attr("safe_")
+	}
+}
+
+var (
+	benchmarkMessage_Attr_populatedLastItem_sink starlark.Value
+	benchmarkMessage_Attr_populatedLastItem_err  error
+)
+
+func BenchmarkMessage_Attr_populatedLastItem(b *testing.B) {
+	msg, err := NewMessage(&pb.MessageV3{Safe_: true})
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+
+	for range b.N {
+		benchmarkMessage_Attr_populatedLastItem_sink, benchmarkMessage_Attr_populatedLastItem_err = msg.Attr("safe_")
+	}
+}
+
+var (
+	benchmarkMessage_SetField_unpopulatedInt32_err error
+)
+
+func BenchmarkMessage_SetField_unpopulatedInt32(b *testing.B) {
+	msg, err := NewMessage(&pb.MessageV3{})
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+
+	si := starlark.MakeInt(100)
+	for range b.N {
+		benchmarkMessage_SetField_unpopulatedInt32_err = msg.SetField("f_int32", si)
+	}
+}
+
+var (
+	benchmarkMessage_SetField_populatedInt32_err error
+)
+
+func BenchmarkMessage_SetField_populatedInt32(b *testing.B) {
+	msg, err := NewMessage(&pb.MessageV3{
+		FInt32: 42,
+	})
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+
+	si := starlark.MakeInt(100)
+	for range b.N {
+		benchmarkMessage_SetField_populatedInt32_err = msg.SetField("f_int32", si)
+	}
+}
+
+var (
+	benchmarkMessage_SetField_unpopulatedLastItem_err error
+)
+
+func BenchmarkMessage_SetField_unpopulatedLastItem(b *testing.B) {
+	msg, err := NewMessage(&pb.MessageV3{})
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+
+	for range b.N {
+		benchmarkMessage_SetField_unpopulatedLastItem_err = msg.SetField("safe_", starlark.True)
+	}
+}
+
+var (
+	benchmarkMessage_SetField_populatedLastItem_err error
+)
+
+func BenchmarkMessage_SetField_populatedLastItem(b *testing.B) {
+	msg, err := NewMessage(&pb.MessageV3{Safe_: true})
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+
+	for range b.N {
+		benchmarkMessage_SetField_populatedLastItem_err = msg.SetField("safe_", starlark.True)
+	}
+}

--- a/go/protomodule/merge.go
+++ b/go/protomodule/merge.go
@@ -84,7 +84,7 @@ func mergeField(dst, src starlark.Value) (starlark.Value, error) {
 			return nil, mergeError(dst, src)
 		}
 
-		newMessage, err := NewMessage(dst.msg)
+		newMessage, err := NewMessage(dst.emptyMsg.Interface())
 		if err != nil {
 			return nil, err
 		}

--- a/go/protomodule/merge.go
+++ b/go/protomodule/merge.go
@@ -62,21 +62,7 @@ func mergeField(dst, src starlark.Value) (starlark.Value, error) {
 		}
 
 		newMap := newProtoMap(dst.mapKey, dst.mapValue)
-
-		for _, item := range dst.Items() {
-			err := newMap.SetKey(item[0], item[1])
-			if err != nil {
-				return nil, err
-			}
-		}
-
-		for _, item := range src.Items() {
-			err := newMap.SetKey(item[0], item[1])
-			if err != nil {
-				return nil, err
-			}
-		}
-
+		newMap.dict = dst.dict.Union(src.dict)
 		return newMap, nil
 	case *protoMessage:
 		src, ok := src.(*protoMessage)

--- a/go/protomodule/protomodule_list.go
+++ b/go/protomodule/protomodule_list.go
@@ -107,6 +107,10 @@ func (r *protoRepeated) Append(v starlark.Value) error {
 	return r.list.Append(v)
 }
 
+func (r *protoRepeated) appendUnchecked(v starlark.Value) error {
+	return r.list.Append(v)
+}
+
 func (r *protoRepeated) SetIndex(i int, v starlark.Value) error {
 	err := scalarTypeCheck(r.fieldDesc, v)
 	if err != nil {

--- a/go/protomodule/protomodule_map.go
+++ b/go/protomodule/protomodule_map.go
@@ -50,10 +50,14 @@ var _ starlark.HasSetKey = (*protoMap)(nil)
 var _ starlark.Comparable = (*protoMap)(nil)
 
 func newProtoMap(mapKey protoreflect.FieldDescriptor, mapValue protoreflect.FieldDescriptor) *protoMap {
+	return newProtoMapSize(mapKey, mapValue, 0)
+}
+
+func newProtoMapSize(mapKey protoreflect.FieldDescriptor, mapValue protoreflect.FieldDescriptor, size int) *protoMap {
 	return &protoMap{
 		mapKey:   mapKey,
 		mapValue: mapValue,
-		dict:     starlark.NewDict(0),
+		dict:     starlark.NewDict(size),
 	}
 }
 
@@ -177,6 +181,20 @@ func (m *protoMap) SetKey(k, v starlark.Value) error {
 	// Typecheck value
 	err = scalarTypeCheck(m.mapValue, v)
 	if err != nil {
+		return err
+	}
+
+	return m.dict.SetKey(k, v)
+}
+
+// setKeyUnchecked is the same as [protoMap.SetKey], but assumes that k and v
+// have already been type-checked against the map's key and value types.
+func (m *protoMap) setKeyUnchecked(k, v starlark.Value) error {
+	// Pre 1.0 compatibility allowed maps to be constructed with None in proto2
+	// with the value treated as nil. protoreflect does not allow setting
+	// with a value of nil, so instead treat it as an unset
+	if fieldAllowsNone(m.mapValue) && v == starlark.None {
+		_, _, err := m.dict.Delete(k)
 		return err
 	}
 

--- a/go/protomodule/protomodule_message.go
+++ b/go/protomodule/protomodule_message.go
@@ -61,15 +61,12 @@ func NewMessage(msg proto.Message) (*protoMessage, error) {
 		return nil, rangeErr
 	}
 
-	// Clone and reset the input msg to ensure no mutations
-	cloned := proto.Clone(msg)
-	proto.Reset(cloned)
-
+	emptyMsg := msgReflect.New()
 	return &protoMessage{
-		msg:     cloned,
-		msgDesc: msgReflect.Descriptor(),
-		fields:  fields,
-		frozen:  false,
+		emptyMsg: emptyMsg,
+		msgDesc:  msgReflect.Descriptor(),
+		fields:   fields,
+		frozen:   false,
 	}, nil
 }
 
@@ -90,11 +87,10 @@ func AsProtoMessage(v starlark.Value) (proto.Message, bool) {
 // proto.Message through AsProtoMessage. Any fields set to starlark.None or the
 // default field value will be ignored when returning to a protobuf.Message
 type protoMessage struct {
-	// A copy of the underlying is stored so AsProtoMessage can construct a new object
-	msg     proto.Message
-	msgDesc protoreflect.MessageDescriptor
-	fields  map[string]starlark.Value
-	frozen  bool
+	emptyMsg protoreflect.Message // prototype of an empty message of this type
+	msgDesc  protoreflect.MessageDescriptor
+	fields   map[string]starlark.Value
+	frozen   bool
 }
 
 var _ starlark.Value = (*protoMessage)(nil)
@@ -284,7 +280,7 @@ func (msg *protoMessage) SetField(name string, val starlark.Value) error {
 	}
 
 	// If valueFromStarlark returns an error, the val cannot be assigned to the field
-	_, err := valueFromStarlark(msg.msg.ProtoReflect(), fieldDesc, val)
+	_, err := valueFromStarlark(msg.emptyMsg, fieldDesc, val)
 	if err != nil {
 		return err
 	}
@@ -364,8 +360,7 @@ func (msg *protoMessage) Merge(other *protoMessage) error {
 
 // Construct a new instance of msg.msg and set each field on msg.fields
 func (msg *protoMessage) toProtoMessage() proto.Message {
-	out := proto.Clone(msg.msg)
-	proto.Reset(out)
+	out := msg.emptyMsg.New()
 
 	// All entries in msg.fields should exist as fields on the message, and
 	// the values be the corresponding type, checked in SetField
@@ -375,15 +370,15 @@ func (msg *protoMessage) toProtoMessage() proto.Message {
 			continue
 		}
 
-		protoValue, err := valueFromStarlark(msg.msg.ProtoReflect(), fieldDesc, val)
+		protoValue, err := valueFromStarlark(msg.emptyMsg, fieldDesc, val)
 		if err != nil {
 			continue
 		}
 
-		out.ProtoReflect().Set(fieldDesc, protoValue)
+		out.Set(fieldDesc, protoValue)
 	}
 
-	return out
+	return out.Interface()
 }
 
 func getFieldDescriptor(msgDesc protoreflect.MessageDescriptor, fieldName string) protoreflect.FieldDescriptor {

--- a/go/protomodule/protomodule_message.go
+++ b/go/protomodule/protomodule_message.go
@@ -388,14 +388,7 @@ func (msg *protoMessage) toProtoMessage() proto.Message {
 
 func getFieldDescriptor(msgDesc protoreflect.MessageDescriptor, fieldName string) protoreflect.FieldDescriptor {
 	fields := msgDesc.Fields()
-	for i := 0; i < fields.Len(); i++ {
-		field := fields.Get(i)
-		if fieldName == string(field.Name()) {
-			return field
-		}
-	}
-
-	return nil
+	return fields.ByName(protoreflect.Name(fieldName))
 }
 
 // Return if a value is not the default

--- a/go/protomodule/type_conversions.go
+++ b/go/protomodule/type_conversions.go
@@ -215,7 +215,7 @@ func listValueToStarlark(listVal protoreflect.List, fieldDesc protoreflect.Field
 		if err != nil {
 			return starlark.None, err
 		}
-		out.Append(starlarkValue)
+		out.appendUnchecked(starlarkValue)
 	}
 	return out, nil
 }

--- a/go/protomodule/type_conversions.go
+++ b/go/protomodule/type_conversions.go
@@ -265,9 +265,9 @@ func mapValueToStarlark(mapVal protoreflect.Map, keyType, valueType protoreflect
 		less, _ := starlark.Compare(syntax.LT, kvs[i].key, kvs[j].key)
 		return less
 	})
-	out := newProtoMap(keyType, valueType)
+	out := newProtoMapSize(keyType, valueType, len(kvs))
 	for _, item := range kvs {
-		if err := out.SetKey(item.key, item.value); err != nil {
+		if err := out.setKeyUnchecked(item.key, item.value); err != nil {
 			return starlark.None, err
 		}
 	}


### PR DESCRIPTION
```
❯ go install golang.org/x/perf/cmd/benchstat@latest
❯ go test -bench=. -count=10 ./go/protomodule >before|after.txt
❯ ~/go/bin/benchstat before.txt after.txt 
goos: darwin
goarch: arm64
pkg: github.com/stripe/skycfg/go/protomodule
cpu: Apple M1 Max
                                        │  before.txt  │              after.txt               │
                                        │    sec/op    │    sec/op     vs base                │
NewMessage_empty-10                        507.2n ± 6%   457.6n ± 10%   -9.77% (p=0.002 n=10)
NewMessage_full-10                         14.99µ ± 5%   10.21µ ±  9%  -31.94% (p=0.000 n=10)
Message_Attr_unpopulatedScalar-10          27.00n ± 3%   31.99n ±  2%  +18.46% (p=0.000 n=10)
Message_Attr_populatedScalar-10            9.104n ± 5%   8.797n ±  2%        ~ (p=0.052 n=10)
Message_Attr_unpopulatedList-10            294.6n ± 3%   155.5n ± 10%  -47.23% (p=0.000 n=10)
Message_Attr_populatedList-10              8.719n ± 4%   8.457n ±  3%        ~ (p=0.165 n=10)
Message_Attr_unpopulatedLastItem-10       259.25n ± 4%   36.44n ±  1%  -85.94% (p=0.000 n=10)
Message_Attr_populatedLastItem-10          15.24n ± 3%   15.05n ±  2%        ~ (p=0.382 n=10)
Message_SetField_unpopulatedInt32-10       41.20n ± 4%   41.73n ±  2%        ~ (p=0.247 n=10)
Message_SetField_populatedInt32-10         40.85n ± 4%   41.79n ±  3%   +2.30% (p=0.023 n=10)
Message_SetField_unpopulatedLastItem-10   264.70n ± 4%   48.40n ±  4%  -81.72% (p=0.000 n=10)
Message_SetField_populatedLastItem-10     266.85n ± 4%   48.77n ±  3%  -81.72% (p=0.000 n=10)
geomean                                    107.0n        62.99n        -41.14%
```

* `NewMessage_empty-10` got faster mostly because of the replacement of `proto.Clone` + `proto.Reset` with `msg.ProtoReflect().New()`.
* `NewMessage_full-10` got faster due to the removal of `proto.Clone` and the use of `appendUnchecked` + `setKeyUnchecked`.
* `Message_Attr_unpopulatedScalar-10` and `Message_SetField_*Int32-10` got a little slower, primarily because those fields are near the beginning of the message descriptor, so the current linear scan in `getFieldDescriptor` ends up being faster than a `map` lookup. However, the same change made `BenchmarkMessage_Attr_unpopulatedList-10`, `Message_Attr_unpopulatedLastItem-10`, and `Message_SetField_*LastItem-10` **much** faster, so it's worth it overall