### PR TITLE
parallelmodule: Create

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -18,6 +18,13 @@ bazel_dep(
     version = "0.5.0",
 )
 
+single_version_override(
+    module_name = "rules_go",
+    patch_strip = 1,
+    # Only necessary for Go <1.24. Remove when we bump the minimum version.
+    patches = ["//tools:rules_go_macos.patch"],
+)
+
 protobuf_version = "30.1"
 
 protoc = use_extension("@toolchains_protoc//protoc:extensions.bzl", "protoc")
@@ -49,4 +56,5 @@ use_repo(
     "in_gopkg_yaml_v2",
     "net_starlark_go",
     "org_golang_google_protobuf",
+    "org_golang_x_sync",
 )

--- a/docs/modules.asciidoc
+++ b/docs/modules.asciidoc
@@ -62,6 +62,42 @@ order.
  "hello=a&world=b"
  >>>
 
+== parallel
+
+Functions for running code in parallel.
+This module is not loaded by skycfg by default;
+the embedder must explicitly opt into making this available.
+
+Index:
+
+ * `<<parallel.map>>`
+
+=== `parallel.map`
+[[parallel.map]]
+
+`parallel.map(function, iterable)` runs `function` on each element of
+`iterable` in parallel.
+Returns a list containing the result of `function`, in the same order as the
+original iterable.
+If any call to `function` fails, `parallel.map` fails as well.
+If multiple invocations fail, the error is chosen arbitrarily.
+
+To guarantee safety, the following measures are taken:
+
+ * The `function` and all elements of `iterable` are frozen.
+ * `map` cannot be called during module initialization.
+   See https://github.com/google/starlark-go/issues/623[google/starlark-go#623].
+ * `map` detects and forbids recursion, even if Starlark is configured to allow
+   recursion.
+
+[source,python]
+----
+>>> def run(value):
+...   return value + 42
+>>> parallel.map(run, [1, 2, 3])
+[43, 44, 45]
+----
+
 == proto
 
 Functions for constructing, modifying, and encoding

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/spaolacci/murmur3 v1.1.0
 	github.com/stretchr/testify v1.10.0
 	go.starlark.net v0.0.0-20250623223156-8bf495bf4e9a
+	golang.org/x/sync v0.11.0
 	google.golang.org/protobuf v1.36.3
 	gopkg.in/yaml.v2 v2.2.8
 )

--- a/go.sum
+++ b/go.sum
@@ -16,12 +16,12 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 go.starlark.net v0.0.0-20250623223156-8bf495bf4e9a h1:4JpDHHQ9BoQWTX4F6nMBaZCz7OePNidT395Mr6ipbP8=
 go.starlark.net v0.0.0-20250623223156-8bf495bf4e9a/go.mod h1:YKMCv9b1WrfWmeqdV5MAuEHWsu5iC+fe6kYl2sQjdI8=
+golang.org/x/sync v0.11.0 h1:GGz8+XQP4FvTTrjZPzNKTMFtSXH80RAzG+5ghFPgK9w=
+golang.org/x/sync v0.11.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
-google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 google.golang.org/protobuf v1.36.3 h1:82DV7MYdb8anAVi3qge1wSnMDrnKK7ebr+I0hHRN1BU=
 google.golang.org/protobuf v1.36.3/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/go/parallelmodule/BUILD.bazel
+++ b/go/parallelmodule/BUILD.bazel
@@ -1,0 +1,29 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "parallelmodule",
+    srcs = [
+        "parallelmodule.go",
+        "thread.go",
+    ],
+    importpath = "github.com/stripe/skycfg/go/parallelmodule",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@net_starlark_go//starlark",
+        "@net_starlark_go//starlarkstruct",
+        "@net_starlark_go//syntax",
+        "@org_golang_x_sync//errgroup",
+    ],
+)
+
+go_test(
+    name = "parallelmodule_test",
+    srcs = ["parallelmodule_test.go"],
+    embed = [":parallelmodule"],
+    deps = [
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+        "@net_starlark_go//starlark",
+        "@net_starlark_go//syntax",
+    ],
+)

--- a/go/parallelmodule/parallelmodule.go
+++ b/go/parallelmodule/parallelmodule.go
@@ -1,0 +1,194 @@
+// Package parallelmodule contains Starlark functions for running code in parallel.
+// Unlike other Starlark modules in skycfg, this module is not loaded by skycfg by default.
+package parallelmodule
+
+import (
+	"fmt"
+
+	"go.starlark.net/starlark"
+	"go.starlark.net/starlarkstruct"
+	"go.starlark.net/syntax"
+	"golang.org/x/sync/errgroup"
+)
+
+// NewModule returns a Starlark module of parallel functions.
+//
+//	parallel = module(
+//	    map,
+//	)
+//
+// def map(function, iterable):
+//
+// Runs function on each element of iterable in parallel.
+// Returns a list containing the result of function, in the same order as the
+// original iterable.
+// If any call to function fails, parallel.map fails as well.
+// If multiple invocations fail, the error is chosen arbitrarily.
+//
+// To guarantee safety, the following measures are taken:
+//   - The function and each element of iterable are frozen.
+//   - map cannot be called during module initialization.
+//     See https://github.com/google/starlark-go/issues/623.
+//   - map detects and forbids recursion, even if Starlark is configured to
+//     allow recursion.
+var Module = &starlarkstruct.Module{
+	Name: "parallel",
+	Members: starlark.StringDict{
+		"map": starlark.NewBuiltin("parallel.map", parMap),
+	},
+}
+
+// makeTrampoline creates a function appropriate for [starlark.NewBuiltin] that
+// just calls the provided callable with args and wargs.
+func makeTrampoline(callable starlark.Callable) func(_ *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	return func(t *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+		return starlark.Call(t, callable, args, kwargs)
+	}
+}
+
+// callableWithPos is a callable that always has the given position in a stack trace.
+type callableWithPos struct {
+	starlark.Callable
+	pos syntax.Position
+}
+
+func (f callableWithPos) Position() syntax.Position {
+	return f.pos
+}
+
+// replicateStack creates a Starlark callable that, when called, adds the call
+// frames of t to the call stack, and then calls fn.
+func replicateStack(t *starlark.Thread, fn starlark.Callable) starlark.Callable {
+	for depth := range t.CallStackDepth() {
+		fr := t.CallFrame(depth)
+		builtin := starlark.NewBuiltin(fr.Name, makeTrampoline(fn))
+		fn = callableWithPos{builtin, fr.Pos}
+	}
+	return fn
+}
+
+func checkRecursionOrInitialization(t *starlark.Thread, fn *starlark.Builtin) error {
+	seenPos := map[syntax.Position]struct{}{}
+	for depth := range t.CallStackDepth() {
+		fr := t.CallFrame(depth)
+
+		// We cannot guarantee data race freedom during module initialization,
+		// because freezing a function does not prevent a global from being
+		// modified or reassigned (if -globalreassign).
+		// See https://github.com/google/starlark-go/issues/623.
+		//
+		// Merely freezing the mapper's globals is **not** sufficient:
+		// the iterable can also contain functions with access to globals.
+		// See TestMap_mutate_global_during_toplevel2.
+		//
+		// On the other hand, if a module is fully initialized, race freedom is
+		// guaranteed:
+		//  1. Globals can never be reassigned by non-top-level Starlark functions.
+		//  2. Global values must have been frozen already at the end of module
+		//     initialization.
+		if fr.Name == "<toplevel>" {
+			return fmt.Errorf("function %s cannot be called during module top-level initialization", fn.Name())
+		}
+
+		// This is not entirely foolproof, since:
+		//  1. we only check for cross-thread recursion if a parallel function
+		//     is called;
+		//  2. checkRecursion checks frame positions, not function code identity
+		//     like Starlark itself.
+		//
+		// But in practice this is good enough to guarantee no infinite loop.
+		// See TestMap_recurse_benign for a code sample that is allowed under this
+		// check, but not by Starlark in single-threaded execution.
+		if fr.Pos.Filename() == "<builtin>" {
+			// built-in function; ignore
+			continue
+		}
+		if _, ok := seenPos[fr.Pos]; ok {
+			return fmt.Errorf("function %s called recursively", fr.Name)
+		}
+		seenPos[fr.Pos] = struct{}{}
+	}
+	return nil
+}
+
+// par implements part of the function:
+//
+//	def par(callable, iterable):
+//
+// It calls callable on each element of iterable, and returns a slice of result
+// values.
+func par(t *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) ([]starlark.Value, error) {
+	fnName := fn.Name()
+
+	var mapper starlark.Callable
+	var iterable starlark.Iterable
+	if err := starlark.UnpackPositionalArgs(fnName, args, kwargs, 2, &mapper, &iterable); err != nil {
+		return nil, err
+	}
+
+	if err := checkRecursionOrInitialization(t, fn); err != nil {
+		return nil, err
+	}
+
+	// Important: freeze inputs to prevent data races.
+	mapper.Freeze()
+	inputs := toFrozenSlice(iterable)
+
+	out := make([]starlark.Value, len(inputs))
+
+	var eg errgroup.Group
+	for i, val := range inputs {
+		curThread, err := newThread(t, fn.Name(), i)
+		if err != nil {
+			return nil, err
+		}
+
+		var mapCaller starlark.Callable
+
+		// Create a trampoline function with a descriptive name for nice stack traces.
+		mapCaller = starlark.NewBuiltin(fmt.Sprintf("%s.fn[%d]", fnName, i), makeTrampoline(mapper))
+
+		// Replicate the stack of the parent thread.
+		// This is important for two reasons:
+		//   1. It makes checkRecursion work across threads.
+		//   2. In case of evaluation error, the captured stack trace will
+		//      include the stack from the parent thread.
+		mapCaller = replicateStack(t, mapCaller)
+
+		eg.Go(func() error {
+			mappedVal, err := starlark.Call(curThread, mapCaller, starlark.Tuple{val}, nil)
+			if err != nil {
+				return err
+			}
+			out[i] = mappedVal
+			return nil
+		})
+	}
+
+	err := eg.Wait()
+	if err != nil {
+		return nil, err
+	}
+
+	return out, nil
+}
+
+func parMap(t *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+	vals, err := par(t, fn, args, kwargs)
+	if err != nil {
+		return nil, err
+	}
+	return starlark.NewList(vals), nil
+}
+
+// toFrozenSlice converts an iterable to a slice of frozen values.
+func toFrozenSlice(seq starlark.Iterable) (out []starlark.Value) {
+	iter := seq.Iterate()
+	defer iter.Done()
+	var elem starlark.Value
+	for iter.Next(&elem) {
+		elem.Freeze()
+		out = append(out, elem)
+	}
+	return out
+}

--- a/go/parallelmodule/parallelmodule_test.go
+++ b/go/parallelmodule/parallelmodule_test.go
@@ -51,7 +51,7 @@ func TestMap_basic_go(t *testing.T) {
 	s := starlark.NewSet(len(elements))
 	for _, val := range elements {
 		err := s.Insert(val)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	}
 
 	seen := make(chan starlark.Value, 10)

--- a/go/parallelmodule/parallelmodule_test.go
+++ b/go/parallelmodule/parallelmodule_test.go
@@ -1,0 +1,504 @@
+package parallelmodule
+
+import (
+	"errors"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.starlark.net/starlark"
+	"go.starlark.net/syntax"
+)
+
+func TestCallableWithPos(t *testing.T) {
+	t.Parallel()
+
+	var callStack starlark.CallStack
+
+	l := new(starlark.List)
+	expectedArgs := starlark.Tuple{l}
+	expectedKwargs := []starlark.Tuple{{starlark.String("foo"), l}}
+	builtin := starlark.NewBuiltin("test", func(thread *starlark.Thread, _ *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+		assert.Equal(t, expectedArgs, args)
+		assert.Equal(t, expectedKwargs, kwargs)
+		callStack = thread.CallStack()
+		return starlark.None, nil
+	})
+
+	filename := "foobar"
+	pos := syntax.MakePosition(&filename, 42, 1)
+	callable := callableWithPos{builtin, pos}
+	_, err := starlark.Call(new(starlark.Thread), callable, expectedArgs, expectedKwargs)
+	if assert.NoError(t, err) {
+		expectedCallStack := starlark.CallStack{
+			{Name: "test", Pos: pos},
+		}
+		assert.Equal(t, expectedCallStack, callStack)
+	}
+}
+
+func TestMap_basic_go(t *testing.T) {
+	t.Parallel()
+
+	elements := []starlark.Value{
+		starlark.String("foo"),
+		starlark.String("bar"),
+		starlark.String("baz"),
+	}
+
+	s := starlark.NewSet(len(elements))
+	for _, val := range elements {
+		err := s.Insert(val)
+		assert.NoError(t, err)
+	}
+
+	seen := make(chan starlark.Value, 10)
+	seenThreads := make(chan *starlark.Thread, 10)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+
+		mapper := starlark.NewBuiltin("mapper", func(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+			seenThreads <- thread
+			assert.Len(t, kwargs, 0)
+			if assert.Len(t, args, 1) {
+				seen <- args[0]
+				return args[0], nil
+			} else {
+				return nil, errors.New("unexpected")
+			}
+		})
+		thread := &starlark.Thread{Name: "root"}
+		res, err := starlark.Call(thread, Module.Members["map"], starlark.Tuple{mapper, s}, nil)
+		close(seen)
+		close(seenThreads)
+
+		if assert.NoError(t, err) {
+			if assert.IsType(t, new(starlark.List), res) {
+				assert.Equal(t, elements, toFrozenSlice(res.(*starlark.List)))
+			}
+		}
+	}()
+
+	<-done
+
+	var seenSlice []starlark.Value
+	for seenArg := range seen {
+		seenSlice = append(seenSlice, seenArg)
+	}
+	assert.ElementsMatch(t, seenSlice, elements)
+
+	seenThreadsSet := map[*starlark.Thread]struct{}{}
+	var seenThreadNames []string
+	for seenThread := range seenThreads {
+		seenThreadNames = append(seenThreadNames, seenThread.Name)
+		seenThreadsSet[seenThread] = struct{}{}
+	}
+	assert.Len(t, seenThreadsSet, len(elements))
+	assert.ElementsMatch(t, seenThreadNames, []string{
+		"root > parallel.map[0]",
+		"root > parallel.map[1]",
+		"root > parallel.map[2]",
+	})
+}
+
+func TestMap_basic(t *testing.T) {
+	t.Parallel()
+
+	fileOpts := &syntax.FileOptions{}
+	root := &starlark.Thread{Name: "root"}
+	prog := `
+def mapper(arg):
+	return str(arg) + " out"
+
+def run():
+	return parallel.map(mapper, range(6))
+`
+	res, err := starlark.ExecFileOptions(fileOpts, root, "TestMap_basic", prog, starlark.StringDict{"parallel": Module})
+	require.NoError(t, err)
+
+	out, err := starlark.Call(root, res["run"], nil, nil)
+	if assert.NoError(t, err) {
+		if assert.IsType(t, new(starlark.List), out) {
+			expected := []starlark.Value{
+				starlark.String("0 out"),
+				starlark.String("1 out"),
+				starlark.String("2 out"),
+				starlark.String("3 out"),
+				starlark.String("4 out"),
+				starlark.String("5 out"),
+			}
+			assert.Equal(t, expected, toFrozenSlice(out.(*starlark.List)))
+		}
+	}
+}
+
+func TestMap_fail(t *testing.T) {
+	t.Parallel()
+
+	fileOpts := &syntax.FileOptions{}
+	root := &starlark.Thread{Name: "root"}
+	prog := `
+def mapper_sub(arg):
+	if arg == 5:
+		fail("oh noes")
+
+def mapper(arg):
+	mapper_sub(arg)
+	return str(arg) + " out"
+
+def run0():
+	parallel.map(mapper, range(6))
+
+def run1():
+	run0()
+
+def run2():
+	run1()
+`
+	res, err := starlark.ExecFileOptions(fileOpts, root, "TestMap_fail", prog, starlark.StringDict{"parallel": Module})
+	require.NoError(t, err)
+
+	_, err = starlark.Call(root, res["run2"], nil, nil)
+	assert.EqualError(t, err, "fail: oh noes")
+	if assert.IsType(t, new(starlark.EvalError), err) {
+		expected := `Traceback (most recent call last):
+  TestMap_fail:17:6: in run2
+  TestMap_fail:14:6: in run1
+  TestMap_fail:11:14: in run0
+  <builtin>: in parallel.map
+  <builtin>: in parallel.map.fn[5]
+  TestMap_fail:7:12: in mapper
+  TestMap_fail:4:7: in mapper_sub
+Error in fail: fail: oh noes`
+		assert.Equal(t, expected, err.(*starlark.EvalError).Backtrace())
+	}
+}
+
+func TestMap_nested(t *testing.T) {
+	t.Parallel()
+
+	fileOpts := &syntax.FileOptions{}
+	root := &starlark.Thread{Name: "root"}
+	prog := `
+def mapper(arg):
+	return parallel.map(lambda x: -x, [arg] * 4)
+
+def run():
+	out = parallel.map(mapper, range(6))
+	expected = [
+		[0, 0, 0, 0],
+		[-1, -1, -1, -1],
+		[-2, -2, -2, -2],
+		[-3, -3, -3, -3],
+		[-4, -4, -4, -4],
+		[-5, -5, -5, -5],
+	]
+	if out != expected:
+		fail("{} != {}".format(out, expected))
+`
+	res, err := starlark.ExecFileOptions(fileOpts, root, "TestMap_nested", prog, starlark.StringDict{"parallel": Module})
+	require.NoError(t, err)
+
+	_, err = starlark.Call(root, res["run"], nil, nil)
+	assert.NoError(t, err)
+}
+
+func TestMap_recurse(t *testing.T) {
+	t.Parallel()
+
+	fileOpts := &syntax.FileOptions{}
+	root := &starlark.Thread{Name: "root"}
+	prog := `
+def mapper(arg):
+	return parallel.map(lambda x: run(), [arg] * 4)
+
+def run():
+	return parallel.map(mapper, range(6))
+`
+	res, err := starlark.ExecFileOptions(fileOpts, root, "TestMap_recurse", prog, starlark.StringDict{"parallel": Module})
+	require.NoError(t, err)
+
+	_, err = starlark.Call(root, res["run"], nil, nil)
+	assert.EqualError(t, err, "function run called recursively")
+	if assert.IsType(t, new(starlark.EvalError), err) {
+		expected := strings.Join([]string{
+			regexp.QuoteMeta(`Traceback (most recent call last):
+  TestMap_recurse:6:21: in run
+  <builtin>: in parallel.map
+  <builtin>: in parallel.map.fn[`), `[0-5]`, regexp.QuoteMeta(`]
+  TestMap_recurse:3:21: in mapper
+  <builtin>: in parallel.map
+  <builtin>: in parallel.map.fn[`), `[0-3]`, regexp.QuoteMeta(`]
+  TestMap_recurse:3:35: in lambda
+  TestMap_recurse:6:21: in run
+Error in parallel.map: function run called recursively`),
+		}, "")
+
+		assert.Regexp(t, expected, err.(*starlark.EvalError).Backtrace())
+	}
+}
+
+// This is an example of recursion check not being exhaustive (we allow rec to
+// be called on a different thread). But in practice, it is benign: we can
+// guarantee that no infinite loop can result from this type of recursion.
+func TestMap_recurse_benign(t *testing.T) {
+	t.Parallel()
+
+	fileOpts := &syntax.FileOptions{}
+	root := &starlark.Thread{Name: "root"}
+	prog := `
+def rec(x):
+	if x < 50:
+		return [x]
+	return parallel.map(rec, range(4))
+
+def run():
+	out = rec(100)
+	expected = [
+		[0],
+		[1],
+		[2],
+		[3],
+	]
+	if out != expected:
+		fail("{} != {}".format(out, expected))
+`
+	res, err := starlark.ExecFileOptions(fileOpts, root, "TestMap_recurse_benign", prog, starlark.StringDict{"parallel": Module})
+	require.NoError(t, err)
+
+	_, err = starlark.Call(root, res["run"], nil, nil)
+	assert.NoError(t, err)
+}
+
+func TestMap_mutate_global_during_toplevel(t *testing.T) {
+	t.Parallel()
+
+	fileOpts := &syntax.FileOptions{}
+	root := &starlark.Thread{Name: "root"}
+	prog := `
+d = {}
+
+def mapper(x):
+	d[x] = x # this doesn't work
+
+def run():
+	return parallel.map(mapper, range(6))
+
+run()
+`
+	_, err := starlark.ExecFileOptions(fileOpts, root, "TestMap_mutate_global_during_toplevel", prog, starlark.StringDict{"parallel": Module})
+	assert.EqualError(t, err, "function parallel.map cannot be called during module top-level initialization")
+	if assert.IsType(t, new(starlark.EvalError), err) {
+		expected := `Traceback (most recent call last):
+  TestMap_mutate_global_during_toplevel:10:4: in <toplevel>
+  TestMap_mutate_global_during_toplevel:8:21: in run
+Error in parallel.map: function parallel.map cannot be called during module top-level initialization`
+
+		assert.Equal(t, expected, err.(*starlark.EvalError).Backtrace())
+	}
+}
+
+func TestMap_mutate_global_during_toplevel2(t *testing.T) {
+	t.Parallel()
+
+	fileOpts := &syntax.FileOptions{}
+	root := &starlark.Thread{Name: "root"}
+	runSelf := starlark.NewBuiltin("run_self", func(thread *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs []starlark.Tuple) (starlark.Value, error) {
+		var callable starlark.Callable
+		if err := starlark.UnpackPositionalArgs(fn.Name(), args, kwargs, 1, &callable); err != nil {
+			return nil, err
+		}
+		return starlark.Call(thread, callable, nil, nil)
+	})
+	prog := `
+d = {}
+
+def run():
+	def fn1(): d[2] = 43
+	def fn2(): d[2] = 44
+	def fn3(): d[2] = 45
+
+	d[1] = 42 # this works
+	return parallel.map(run_self, [fn1, fn2, fn3])
+
+run()
+`
+	globals := starlark.StringDict{"parallel": Module, "run_self": runSelf}
+	_, err := starlark.ExecFileOptions(fileOpts, root, "TestMap_mutate_global_during_toplevel2", prog, globals)
+	assert.EqualError(t, err, "function parallel.map cannot be called during module top-level initialization")
+	if assert.IsType(t, new(starlark.EvalError), err) {
+		expected := `Traceback (most recent call last):
+  TestMap_mutate_global_during_toplevel2:12:4: in <toplevel>
+  TestMap_mutate_global_during_toplevel2:10:21: in run
+Error in parallel.map: function parallel.map cannot be called during module top-level initialization`
+
+		assert.Equal(t, expected, err.(*starlark.EvalError).Backtrace())
+	}
+}
+
+func TestMap_mutate_global_after_module_eval(t *testing.T) {
+	t.Parallel()
+
+	fileOpts := &syntax.FileOptions{}
+	root := &starlark.Thread{Name: "root"}
+	prog := `
+d = {}
+
+def mapper(x):
+	d[x] = x # this doesn't work
+
+def run():
+	return parallel.map(mapper, range(6))
+`
+	res, err := starlark.ExecFileOptions(fileOpts, root, "TestMap_mutate_global_after_module_eval", prog, starlark.StringDict{"parallel": Module})
+	require.NoError(t, err)
+
+	_, err = starlark.Call(root, res["run"], nil, nil)
+	assert.EqualError(t, err, "cannot insert into frozen hash table")
+	if assert.IsType(t, new(starlark.EvalError), err) {
+		expected := strings.Join([]string{
+			regexp.QuoteMeta(`Traceback (most recent call last):
+  TestMap_mutate_global_after_module_eval:8:21: in run
+  <builtin>: in parallel.map
+  <builtin>: in parallel.map.fn[`), `[0-5]`, regexp.QuoteMeta(`]
+  TestMap_mutate_global_after_module_eval:5:3: in mapper
+Error: cannot insert into frozen hash table`),
+		}, "")
+
+		assert.Regexp(t, expected, err.(*starlark.EvalError).Backtrace())
+	}
+}
+
+func TestMap_mutate_freevar(t *testing.T) {
+	t.Parallel()
+
+	fileOpts := &syntax.FileOptions{}
+	root := &starlark.Thread{Name: "root"}
+	prog := `
+def run():
+	d = {}
+	def mapper(x):
+		d[x] = x # this doesn't work
+	d[1] = 42 # this works
+	return parallel.map(mapper, range(6))
+`
+	res, err := starlark.ExecFileOptions(fileOpts, root, "TestMap_mutate_freevar", prog, starlark.StringDict{"parallel": Module})
+	require.NoError(t, err)
+
+	_, err = starlark.Call(root, res["run"], nil, nil)
+	assert.EqualError(t, err, "cannot insert into frozen hash table")
+	if assert.IsType(t, new(starlark.EvalError), err) {
+		expected := strings.Join([]string{
+			regexp.QuoteMeta(`Traceback (most recent call last):
+  TestMap_mutate_freevar:7:21: in run
+  <builtin>: in parallel.map
+  <builtin>: in parallel.map.fn[`), `[0-5]`, regexp.QuoteMeta(`]
+  TestMap_mutate_freevar:5:4: in mapper
+Error: cannot insert into frozen hash table`),
+		}, "")
+
+		assert.Regexp(t, expected, err.(*starlark.EvalError).Backtrace())
+	}
+}
+
+func TestMap_mutate_input(t *testing.T) {
+	t.Parallel()
+
+	fileOpts := &syntax.FileOptions{}
+	root := &starlark.Thread{Name: "root"}
+	prog := `
+def run():
+	def mapper(x):
+		x.append(1)
+	return parallel.map(mapper, [[]] * 6)
+`
+	res, err := starlark.ExecFileOptions(fileOpts, root, "TestMap_mutate_input", prog, starlark.StringDict{"parallel": Module})
+	require.NoError(t, err)
+
+	_, err = starlark.Call(root, res["run"], nil, nil)
+	assert.EqualError(t, err, "append: cannot append to frozen list")
+	if assert.IsType(t, new(starlark.EvalError), err) {
+		expected := strings.Join([]string{
+			regexp.QuoteMeta(`Traceback (most recent call last):
+  TestMap_mutate_input:5:21: in run
+  <builtin>: in parallel.map
+  <builtin>: in parallel.map.fn[`), `[0-5]`, regexp.QuoteMeta(`]
+  TestMap_mutate_input:4:11: in mapper
+Error in append: append: cannot append to frozen list`),
+		}, "")
+
+		assert.Regexp(t, expected, err.(*starlark.EvalError).Backtrace())
+	}
+}
+
+func TestMap_mutate_input2(t *testing.T) {
+	t.Parallel()
+
+	fileOpts := &syntax.FileOptions{}
+	root := &starlark.Thread{Name: "root"}
+	prog := `
+def run():
+	l = [[] for _ in range(6)]
+	parallel.map(lambda x: None, l)
+	l[3].append(1)
+`
+	res, err := starlark.ExecFileOptions(fileOpts, root, "TestMap_mutate_input2", prog, starlark.StringDict{"parallel": Module})
+	require.NoError(t, err)
+
+	_, err = starlark.Call(root, res["run"], nil, nil)
+	assert.EqualError(t, err, "append: cannot append to frozen list")
+	if assert.IsType(t, new(starlark.EvalError), err) {
+		expected := `Traceback (most recent call last):
+  TestMap_mutate_input2:5:13: in run
+Error in append: append: cannot append to frozen list`
+
+		assert.Equal(t, expected, err.(*starlark.EvalError).Backtrace())
+	}
+}
+
+// Only the input's elements are frozen, not the entire input iterable.
+func TestMap_input_not_frozen(t *testing.T) {
+	t.Parallel()
+
+	fileOpts := &syntax.FileOptions{}
+	root := &starlark.Thread{Name: "root"}
+	prog := `
+def assert_equal(x, y):
+	if x != y:
+		fail("{} != {}".format(x, y))
+
+def run():
+	l = [[]] * 6
+	out = parallel.map(lambda x: None, l)
+	l.append(42) # should work
+	assert_equal(out, [None] * 6)
+	assert_equal(l, [[]] * 6 + [42])
+
+	d = {1: [], 2: []}
+	out = parallel.map(lambda x: 2 * x, d)
+	d[1].append(1) # should work
+	d[3] = [3] # should work
+	assert_equal(out, [2, 4])
+	assert_equal(d, {1: [1], 2: [], 3: [3]})
+`
+	res, err := starlark.ExecFileOptions(fileOpts, root, "TestMap_input_not_frozen", prog, starlark.StringDict{"parallel": Module})
+	require.NoError(t, err)
+
+	_, err = starlark.Call(root, res["run"], nil, nil)
+	assert.NoError(t, err)
+}
+
+// When we have go1.23, we can just do slices.Collect(l.Elements()).
+func starlarkListToSlice(l *starlark.List) (out []starlark.Value) {
+	iter := l.Iterate()
+	defer iter.Done()
+	var elem starlark.Value
+	for iter.Next(&elem) {
+		out = append(out, elem)
+	}
+	return out
+}

--- a/go/parallelmodule/thread.go
+++ b/go/parallelmodule/thread.go
@@ -1,0 +1,45 @@
+package parallelmodule
+
+import (
+	"context"
+	"fmt"
+
+	"go.starlark.net/starlark"
+)
+
+const (
+	contextKey       = "context"
+	threadCreatorKey = "parallel.thread_creator" // ThreadCreator
+
+	parentThreadKey = "parallel.parent_thread" // *starlark.Thread
+)
+
+type ThreadCreator func(parent *starlark.Thread, parallelFunc string, idx int) *starlark.Thread
+
+func GetThreadCreator(t *starlark.Thread) ThreadCreator {
+	if tc, ok := t.Local(threadCreatorKey).(ThreadCreator); ok {
+		return tc
+	}
+	return DefaultThreadCreator
+}
+
+func DefaultThreadCreator(parent *starlark.Thread, parallelFunc string, idx int) *starlark.Thread {
+	nt := &starlark.Thread{
+		Name:  fmt.Sprintf("%s > %s[%d]", parent.Name, parallelFunc, idx),
+		Print: parent.Print,
+	}
+	if ctx, ok := parent.Local(contextKey).(context.Context); ok {
+		nt.SetLocal(contextKey, ctx)
+	}
+	if tc, ok := parent.Local(threadCreatorKey).(ThreadCreator); ok {
+		nt.SetLocal(threadCreatorKey, tc)
+	}
+	return nt
+}
+
+func newThread(parent *starlark.Thread, parallelFunc string, idx int) (*starlark.Thread, error) {
+	tc := GetThreadCreator(parent)
+	nt := tc(parent, parallelFunc, idx)
+	nt.SetLocal(parentThreadKey, parent)
+	return nt, nil
+}

--- a/go/protomodule/BUILD
+++ b/go/protomodule/BUILD
@@ -34,6 +34,7 @@ go_library(
 go_test(
     name = "protomodule_test",
     srcs = [
+        "bench_test.go",
         "iter_test.go",
         "protomodule_message_test.go",
         "protomodule_test.go",

--- a/tools/rules_go_macos.patch
+++ b/tools/rules_go_macos.patch
@@ -1,0 +1,14 @@
+--- a/go/private/go_toolchain.bzl	2025-08-19 17:40:56.000000000 -0700
++++ b/go/private/go_toolchain.bzl	2025-11-12 21:48:21.186200804 -0800
+@@ -111,6 +111,11 @@
+             cgo_link_flags.extend(["-shared", "-Wl,-all_load"])
+         if host_goos == "linux":
+             cgo_link_flags.append("-Wl,-whole-archive")
++        if p.goos == "darwin":
++            # Add -B gobuildid for compatibility with macOS 26.
++            # Only necessary before Go 1.24.
++            # See https://go.dev/issues/68678
++            link_flags.extend(["-B", "gobuildid"])
+ 
+         go_toolchain(
+             name = "go_" + p.name + "-impl",


### PR DESCRIPTION
Create a module for running Starlark functions in parallel. Starlark is designed to support safe parallel evaluation, so why not make some functions for doing that.

It's not loaded by skycfg by default, because many configuration-based use cases may not want to allow such a powerful feature.

Also fix macOS 26 compatibility by setting the `-B gobuildid` linker flag (https://go.dev/issues/68678); Go 1.24+ set this by default. Without the flag, I get
```
dyld[32468]: missing LC_UUID load command in /private/var/tmp/_bazel/da12fa8050f39c66683875ec236a6a61/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/external/gazelle+/cmd/gazelle/gazelle_/gazelle
dyld[32468]: missing LC_UUID load command
/private/var/tmp/_bazel/da12fa8050f39c66683875ec236a6a61/execroot/_main/bazel-out/darwin_arm64-fastbuild/bin/gazelle: line 112: 32468 Abort trap: 6           "$gazelle_path" "${ARGS[@]}"
```