### PR TITLE
protomodule: return error instead of panicking on non-message args to proto.merge

### DIFF
--- a/go/protomodule/protomodule.go
+++ b/go/protomodule/protomodule.go
@@ -277,8 +277,14 @@ var starlarkMerge = starlark.NewBuiltin("proto.merge", func(
 		return nil, err
 	}
 
-	dst := val1.(*protoMessage)
-	src := val2.(*protoMessage)
+	dst, ok := val1.(*protoMessage)
+	if !ok {
+		return nil, fmt.Errorf("%s: for parameter 1: got %s, want proto.Message", fn.Name(), val1.Type())
+	}
+	src, ok := val2.(*protoMessage)
+	if !ok {
+		return nil, fmt.Errorf("%s: for parameter 2: got %s, want proto.Message", fn.Name(), val2.Type())
+	}
 	if src.Type() != dst.Type() {
 		return nil, fmt.Errorf("%s: types are not the same: got %s and %s", fn.Name(), src.Type(), dst.Type())
 	}

--- a/go/protomodule/protomodule_message_test.go
+++ b/go/protomodule/protomodule_message_test.go
@@ -1043,6 +1043,44 @@ func TestProtoMergeDiffTypes(t *testing.T) {
 	}
 }
 
+func TestProtoMergeNonMessage(t *testing.T) {
+	t.Parallel()
+
+	globals := starlark.StringDict{
+		"proto": NewModule(newRegistry()),
+	}
+
+	tests := []struct {
+		name     string
+		src      string
+		errorMsg string
+	}{
+		{
+			name:     "first arg not a message",
+			src:      `proto.merge("not a message", proto.package("skycfg.test_proto").MessageV2())`,
+			errorMsg: "proto.merge: for parameter 1: got string, want proto.Message",
+		},
+		{
+			name:     "second arg not a message",
+			src:      `proto.merge(proto.package("skycfg.test_proto").MessageV2(), "not a message")`,
+			errorMsg: "proto.merge: for parameter 2: got string, want proto.Message",
+		},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := starlark.Eval(&starlark.Thread{}, "", tc.src, globals)
+			if err == nil {
+				t.Fatalf("expected error %q, got nil", tc.errorMsg)
+			}
+			if tc.errorMsg != err.Error() {
+				t.Errorf("expected error %q, got %q", tc.errorMsg, err.Error())
+			}
+		})
+	}
+}
+
 func TestProtoFreeze_MessageV3(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
The proto.merge builtin used unchecked type assertions on its two arguments, so passing any non-proto-message value from Starlark code would panic the host Go program instead of producing a regular Starlark error. Since proto.merge is exposed directly to user configs, this is reachable from any config that calls it with the wrong type, for example by accident or while iterating on a script.

The fix replaces the assertions with checked conversions that return a normal error, matching the style already used in proto.decode_json, proto.decode_text, and wantSingleProtoMessage in the same file. The error format mirrors those callers ("proto.merge: for parameter N: got X, want proto.Message") so it slots in with the existing error vocabulary.

Added a TestProtoMergeNonMessage test that exercises both argument positions with a Starlark string and verifies the expected error text. The existing TestProtoMergeDiffTypes only covered the case where both args were proto messages of different types, so this new test fills the gap on the non-message path.

Verified with go build ./... and go test on the packages that build outside of Bazel locally. The protomodule unit tests need the bazel-generated test protos to compile, so the new test was written to match the existing TestProtoMergeDiffTypes pattern that CI already runs.