### PR TITLE
allow parallelmodule.map to take a new `limit` arg

### DIFF
--- a/docs/modules.asciidoc
+++ b/docs/modules.asciidoc
@@ -75,12 +75,13 @@ Index:
 === `parallel.map`
 [[parallel.map]]
 
-`parallel.map(function, iterable)` runs `function` on each element of
+`parallel.map(function, iterable, limit=-1)` runs `function` on each element of
 `iterable` in parallel.
 Returns a list containing the result of `function`, in the same order as the
 original iterable.
 If any call to `function` fails, `parallel.map` fails as well.
 If multiple invocations fail, the error is chosen arbitrarily.
+If `limit` is positive, at most `limit` calls to `function` run concurrently.
 
 To guarantee safety, the following measures are taken:
 

--- a/go/parallelmodule/parallelmodule.go
+++ b/go/parallelmodule/parallelmodule.go
@@ -24,7 +24,7 @@ import (
 // original iterable.
 // If any call to function fails, parallel.map fails as well.
 // If multiple invocations fail, the error is chosen arbitrarily.
-// If limit is provided and positive, at most limit goroutines run concurrently.
+// If limit is provided and nonnegative, at most limit goroutines run concurrently.
 //
 // To guarantee safety, the following measures are taken:
 //   - The function and each element of iterable are frozen.

--- a/go/parallelmodule/parallelmodule.go
+++ b/go/parallelmodule/parallelmodule.go
@@ -24,7 +24,7 @@ import (
 // original iterable.
 // If any call to function fails, parallel.map fails as well.
 // If multiple invocations fail, the error is chosen arbitrarily.
-// If limit is provided and nonnegative, at most `limit` goroutines run concurrently.
+// If limit is provided and non-negative, at most `limit` goroutines run concurrently.
 //
 // To guarantee safety, the following measures are taken:
 //   - The function and each element of iterable are frozen.

--- a/go/parallelmodule/parallelmodule.go
+++ b/go/parallelmodule/parallelmodule.go
@@ -17,13 +17,14 @@ import (
 //	    map,
 //	)
 //
-// def map(function, iterable):
+// def map(function, iterable, limit=None):
 //
 // Runs function on each element of iterable in parallel.
 // Returns a list containing the result of function, in the same order as the
 // original iterable.
 // If any call to function fails, parallel.map fails as well.
 // If multiple invocations fail, the error is chosen arbitrarily.
+// If limit is provided and positive, at most limit goroutines run concurrently.
 //
 // To guarantee safety, the following measures are taken:
 //   - The function and each element of iterable are frozen.
@@ -122,7 +123,8 @@ func par(t *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs [
 
 	var mapper starlark.Callable
 	var iterable starlark.Iterable
-	if err := starlark.UnpackPositionalArgs(fnName, args, kwargs, 2, &mapper, &iterable); err != nil {
+	limit := -1
+	if err := starlark.UnpackArgs(fnName, args, kwargs, "function", &mapper, "iterable", &iterable, "limit?", &limit); err != nil {
 		return nil, err
 	}
 
@@ -137,6 +139,9 @@ func par(t *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs [
 	out := make([]starlark.Value, len(inputs))
 
 	var eg errgroup.Group
+	if limit > 0 {
+		eg.SetLimit(limit)
+	}
 	for i, val := range inputs {
 		curThread, err := newThread(t, fn.Name(), i)
 		if err != nil {

--- a/go/parallelmodule/parallelmodule.go
+++ b/go/parallelmodule/parallelmodule.go
@@ -17,7 +17,7 @@ import (
 //	    map,
 //	)
 //
-// def map(function, iterable, limit=None):
+// def map(function, iterable, limit=-1):
 //
 // Runs function on each element of iterable in parallel.
 // Returns a list containing the result of function, in the same order as the
@@ -139,9 +139,7 @@ func par(t *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs [
 	out := make([]starlark.Value, len(inputs))
 
 	var eg errgroup.Group
-	if limit > 0 {
-		eg.SetLimit(limit)
-	}
+	eg.SetLimit(limit)
 	for i, val := range inputs {
 		curThread, err := newThread(t, fn.Name(), i)
 		if err != nil {

--- a/go/parallelmodule/parallelmodule.go
+++ b/go/parallelmodule/parallelmodule.go
@@ -24,7 +24,7 @@ import (
 // original iterable.
 // If any call to function fails, parallel.map fails as well.
 // If multiple invocations fail, the error is chosen arbitrarily.
-// If limit is provided and non-negative, at most `limit` goroutines run concurrently.
+// If limit is positive, at most limit calls to function run concurrently.
 //
 // To guarantee safety, the following measures are taken:
 //   - The function and each element of iterable are frozen.
@@ -139,7 +139,9 @@ func par(t *starlark.Thread, fn *starlark.Builtin, args starlark.Tuple, kwargs [
 	out := make([]starlark.Value, len(inputs))
 
 	var eg errgroup.Group
-	eg.SetLimit(limit)
+	if limit > 0 {
+		eg.SetLimit(limit)
+	}
 	for i, val := range inputs {
 		curThread, err := newThread(t, fn.Name(), i)
 		if err != nil {

--- a/go/parallelmodule/parallelmodule.go
+++ b/go/parallelmodule/parallelmodule.go
@@ -24,7 +24,7 @@ import (
 // original iterable.
 // If any call to function fails, parallel.map fails as well.
 // If multiple invocations fail, the error is chosen arbitrarily.
-// If limit is provided and nonnegative, at most limit goroutines run concurrently.
+// If limit is provided and nonnegative, at most `limit` goroutines run concurrently.
 //
 // To guarantee safety, the following measures are taken:
 //   - The function and each element of iterable are frozen.

--- a/go/parallelmodule/parallelmodule_test.go
+++ b/go/parallelmodule/parallelmodule_test.go
@@ -492,6 +492,37 @@ def run():
 	assert.NoError(t, err)
 }
 
+func TestMap_limit(t *testing.T) {
+	t.Parallel()
+
+	fileOpts := &syntax.FileOptions{}
+	root := &starlark.Thread{Name: "root"}
+	prog := `
+def mapper(arg):
+	return str(arg) + " out"
+
+def run():
+	return parallel.map(mapper, range(6), limit=2)
+`
+	res, err := starlark.ExecFileOptions(fileOpts, root, "TestMap_limit", prog, starlark.StringDict{"parallel": Module})
+	require.NoError(t, err)
+
+	out, err := starlark.Call(root, res["run"], nil, nil)
+	if assert.NoError(t, err) {
+		if assert.IsType(t, new(starlark.List), out) {
+			expected := []starlark.Value{
+				starlark.String("0 out"),
+				starlark.String("1 out"),
+				starlark.String("2 out"),
+				starlark.String("3 out"),
+				starlark.String("4 out"),
+				starlark.String("5 out"),
+			}
+			assert.Equal(t, expected, toFrozenSlice(out.(*starlark.List)))
+		}
+	}
+}
+
 // When we have go1.23, we can just do slices.Collect(l.Elements()).
 func starlarkListToSlice(l *starlark.List) (out []starlark.Value) {
 	iter := l.Iterate()


### PR DESCRIPTION
Adds a new optional arg `limit` to parallelmodule.map.
This allows callers of parallelmodule.map to manage the number of active goroutines in the errgroup. It defaults to `-1`, or "no limit".